### PR TITLE
Fix #62: move to standard Java XML generation to reduce memory usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,5 +41,3 @@ VERSION_GUAVA=27.0.1-jre
 # https://github.com/tomasbjerre/violations-lib/blob/master/CHANGELOG.md
 # https://github.com/tomasbjerre/violations-lib/releases
 VERSION_VIOLATIONS=1.81
-# https://github.com/redundent/kotlin-xml-builder#release-notes
-VERSION_XML_BUILDER=1.4.4

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
 //	compileOnly ("de.aaschmid:gradle-cpd-plugin:1.0")
 	implementation("se.bjurr.violations:violations-lib:${VERSION_VIOLATIONS}")
-	implementation("org.redundent:kotlin-xml-builder:${VERSION_XML_BUILDER}")
 
 	testImplementation(project(":test"))
 	testImplementation(project(":test:internal"))

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -7,7 +7,6 @@ base.archivesBaseName = "twister-quality"
 
 val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_VIOLATIONS: String by project
-val VERSION_XML_BUILDER: String by project
 
 dependencies {
 	implementation(project(":common"))

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsGrouper.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsGrouper.kt
@@ -1,15 +1,14 @@
 package net.twisterrob.gradle.quality.report.html
 
-import net.twisterrob.gradle.common.grouper.Grouper.Start
 import net.twisterrob.gradle.quality.Violation
 import net.twisterrob.gradle.quality.Violations
 
-typealias Category = String?
-typealias Reporter = String
+internal typealias Category = String?
+internal typealias Reporter = String
 
 @Suppress("USELESS_CAST") // casts are useful to convert String to typealias
-internal fun group(results: Start<Violations>): Map<Category, Map<Reporter, List<Violation>>> {
-	val allViolations = results.list.flatMap { (it.violations ?: emptyList()) }
+internal fun group(violationss: List<Violations>): Map<Category, Map<Reporter, List<Violation>>> {
+	val allViolations = violationss.flatMap { (it.violations ?: emptyList()) }
 
 	@Suppress("UnnecessaryVariable") // REPORT broken refactor: inlining this variable breaks code
 	val group = allViolations

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XMLStreamWriterDSL.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XMLStreamWriterDSL.kt
@@ -59,9 +59,17 @@ inline fun XMLStreamWriter.attribute(name: String, value: Any) {
 }
 
 inline fun XMLStreamWriter.cdata(content: String) {
-	writeCData(content)
+	writeCData(content.escapeForCData())
 }
 
 inline fun XMLStreamWriter.cdata(content: Any) {
-	writeCData(content.toString())
+	writeCData(content.toString().escapeForCData())
+}
+
+fun String.escapeForCData(): String {
+	val cdataEnd = """]]>"""
+	val cdataStart = """<![CDATA["""
+	return this
+		// split cdataEnd into two pieces so XML parser doesn't recognize it
+		.replace(cdataEnd, """]]${cdataEnd}${cdataStart}>""")
 }

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XMLStreamWriterDSL.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XMLStreamWriterDSL.kt
@@ -1,0 +1,67 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package net.twisterrob.gradle.quality.report.html
+
+import java.io.Writer
+import javax.xml.stream.XMLStreamWriter
+
+fun Writer.xmlWriter(): XMLStreamWriter =
+	javax.xml.stream.XMLOutputFactory.newInstance().createXMLStreamWriter(this)
+
+fun XMLStreamWriter.use(block: (XMLStreamWriter) -> Unit) {
+	AutoCloseable {
+		this@use.flush()
+		this@use.close()
+	}.use { block(this@use) }
+}
+
+/**
+ * Based on the amazing idea from https://www.schibsted.pl/blog/back-end/readable-xml-kotlin-extensions/
+ * @param encoding be sure to set the underlying Writer's encoding to the same
+ */
+inline fun XMLStreamWriter.document(
+	version: String = "1.0",
+	encoding: String = "utf-8",
+	crossinline content: XMLStreamWriter.() -> Unit
+): XMLStreamWriter = apply {
+	writeStartDocument(encoding, version)
+	content()
+	writeEndDocument()
+}
+
+inline fun XMLStreamWriter.element(
+	name: String,
+	crossinline content: XMLStreamWriter.() -> Unit
+): XMLStreamWriter = apply {
+	writeStartElement(name)
+	content()
+	writeEndElement()
+}
+
+inline fun XMLStreamWriter.element(name: String, content: String) {
+	element(name) {
+		writeCharacters(content)
+	}
+}
+
+inline fun XMLStreamWriter.element(name: String, content: Any) {
+	element(name) {
+		writeCharacters(content.toString())
+	}
+}
+
+inline fun XMLStreamWriter.attribute(name: String, value: String) {
+	writeAttribute(name, value)
+}
+
+inline fun XMLStreamWriter.attribute(name: String, value: Any) {
+	writeAttribute(name, value.toString())
+}
+
+inline fun XMLStreamWriter.cdata(content: String) {
+	writeCData(content)
+}
+
+inline fun XMLStreamWriter.cdata(content: Any) {
+	writeCData(content.toString())
+}

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducer.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducer.kt
@@ -3,28 +3,16 @@ package net.twisterrob.gradle.quality.report.html
 import net.twisterrob.gradle.common.grouper.Grouper
 import net.twisterrob.gradle.quality.Violations
 import org.gradle.api.Project
-import org.redundent.kotlin.xml.Node
 import java.io.File
 
 internal fun Project.produceXml(results: Grouper.Start<Violations>, xmlFile: File, xslFile: File) {
 	val group = group(results.list)
-	val xmlTree = renderXml(group).apply {
-		attribute("project", rootProject.name)
-	}
-	writeXml(xmlTree, xmlFile, xslFile)
-}
-
-internal fun writeXml(xmlTree: Node, xmlFile: File, xslFile: File) {
 	check(xmlFile.parentFile.let { it.isDirectory || it.mkdirs() }) { "Cannot create parent folder for $xmlFile" }
 	check(!xmlFile.exists() || xmlFile.delete()) { "Cannot delete $xmlFile" }
-	// append processing instructions here as the XML lib doesn't allow to do that
-	xmlTree.includeXmlProlog = false
-	xmlFile.bufferedWriter().use { writer ->
-		writer.write("""<?xml version="1.0" encoding="utf-8"?>""" + "\n")
-		val xslPath = xslFile.toRelativeString(xmlFile.parentFile).replace('\\', '/')
-		writer.write("""<?xml-stylesheet type="text/xsl" href="${xslPath}"?>""" + "\n")
-		xmlTree.children.forEach { element ->
-			writer.write((element as Node).toString(prettyFormat = false))
+	val xslPath = xslFile.toRelativeString(xmlFile.parentFile).replace('\\', '/')
+	xmlFile.writer().use { writer ->
+		writer.xmlWriter().use { xmlWriter ->
+			renderXml(xmlWriter, group, this.rootProject.name, xslPath)
 		}
 	}
 }

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducer.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducer.kt
@@ -7,11 +7,11 @@ import org.redundent.kotlin.xml.Node
 import java.io.File
 
 internal fun Project.produceXml(results: Grouper.Start<Violations>, xmlFile: File, xslFile: File) {
-	val group = group(results)
-	val xml = renderXml(group).apply {
+	val group = group(results.list)
+	val xmlTree = renderXml(group).apply {
 		attribute("project", rootProject.name)
 	}
-	writeXml(xml, xmlFile, xslFile)
+	writeXml(xmlTree, xmlFile, xslFile)
 }
 
 private fun writeXml(xml: Node, xmlFile: File, xslFile: File) {

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
@@ -13,7 +13,7 @@ sealed class ContextViewModel {
 
 	/**
 	 * Make sure that any external dependencies are resolved and lazy properties calculated.
-	 * After returning from this a ViewModel is considered ready for consumption
+	 * After returning from this function, a [ContextViewModel] is considered ready for consumption
 	 * and not expected to fail for any reason.
 	 */
 	open fun resolve() = Unit

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
@@ -11,6 +11,13 @@ import kotlin.math.min
 
 sealed class ContextViewModel {
 
+	/**
+	 * Make sure that any external dependencies are resolved and lazy properties calculated.
+	 * After returning from this a ViewModel is considered ready for consumption
+	 * and not expected to fail for any reason.
+	 */
+	open fun resolve() = Unit
+
 	object EmptyContext : ContextViewModel()
 
 	class ErrorContext(
@@ -30,6 +37,11 @@ sealed class ContextViewModel {
 	}
 
 	class CodeContext(private val v: Violation) : ContextViewModel() {
+
+		override fun resolve() {
+			context
+		}
+
 		private val context by lazy { getContext(v) }
 		val type: String get() = "code"
 		val language: String
@@ -78,6 +90,11 @@ sealed class ContextViewModel {
 	}
 
 	class DirectoryContext(private val v: Violation) : ContextViewModel() {
+
+		override fun resolve() {
+			listing
+		}
+
 		val listing by lazy {
 			fun <E> Iterable<E>.replace(old: E, new: E) = map { if (it == old) new else it }
 			fun Array<File>.sorted() = sortedWith(compareBy<File> { !it.isDirectory }.thenBy { it.name })
@@ -97,6 +114,11 @@ sealed class ContextViewModel {
 	}
 
 	class ImageContext(private val v: Violation) : ContextViewModel() {
+
+		override fun resolve() {
+			embeddedPixels
+		}
+
 		val embeddedPixels by lazy {
 			val data = Base64.getEncoder().encodeToString(v.location.file.readBytes())
 			"data:image/${v.location.file.extension};base64,${data}"
@@ -104,6 +126,11 @@ sealed class ContextViewModel {
 	}
 
 	class ArchiveContext(private val v: Violation) : ContextViewModel() {
+
+		override fun resolve() {
+			listing
+		}
+
 		val listing by lazy {
 			val entries = ZipFile(v.location.file).entries().asSequence()
 			entries.map { it.name }.sorted().joinToString("\n")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
@@ -1,16 +1,13 @@
 package net.twisterrob.gradle.quality.report.html
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import java.io.StringWriter
 import kotlin.test.assertEquals
 
 class ViolationsRendererTest {
 
-	@Test fun `xmlWriter impl`() {
-		val writer = StringWriter().xmlWriter()
-		throw Exception(writer::class.toString() + ": " + writer.toString())
-	}
-
+	@DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true") // see #72
 	@Test fun `renderXml writes preamble`() {
 		val out = StringWriter()
 		out.xmlWriter().use { renderXml(it, emptyMap(), "", "some/path/to.xsl") }
@@ -25,6 +22,7 @@ class ViolationsRendererTest {
 		)
 	}
 
+	@DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true") // see #72
 	@Test fun `renderXml writes preamble without stylesheet`() {
 		val out = StringWriter()
 		out.xmlWriter().use { renderXml(it, emptyMap(), "") }
@@ -38,6 +36,7 @@ class ViolationsRendererTest {
 		)
 	}
 
+	@DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true") // see #72
 	@Test fun `renderXml writes project name on root`() {
 		val out = StringWriter()
 		out.xmlWriter().use { renderXml(it, emptyMap(), "project name") }

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
@@ -6,6 +6,11 @@ import kotlin.test.assertEquals
 
 class ViolationsRendererTest {
 
+	@Test fun `xmlWriter impl`() {
+		val writer = StringWriter().xmlWriter()
+		throw Exception(writer::class.toString() + ": " + writer.toString())
+	}
+
 	@Test fun `renderXml writes preamble`() {
 		val out = StringWriter()
 		out.xmlWriter().use { renderXml(it, emptyMap(), "", "some/path/to.xsl") }

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRendererTest.kt
@@ -1,19 +1,51 @@
 package net.twisterrob.gradle.quality.report.html
 
-import org.redundent.kotlin.xml.CDATAElement
-import org.redundent.kotlin.xml.Node
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import kotlin.test.assertEquals
 
-/**
- * Resolve single child path.
- */
-private operator fun Node.invoke(vararg names: String): Node =
-	names.fold(this) { node, name -> node.invoke(name) }
+class ViolationsRendererTest {
 
-/**
- * Resolve only child named `name`.
- */
-private operator fun Node.invoke(name: String): Node =
-	children.filterIsInstance<Node>().single { it.nodeName == name }
+	@Test fun `renderXml writes preamble`() {
+		val out = StringWriter()
+		out.xmlWriter().use { renderXml(it, emptyMap(), "", "some/path/to.xsl") }
 
-private val Node.cdata: CDATAElement
-	get() = children.filterIsInstance<CDATAElement>().single()
+		assertEquals(
+			"""
+				<?xml version="1.0" encoding="utf-8"?>
+				<?xml-stylesheet type="text/xsl" href="some/path/to.xsl"?>
+				<violations project=""></violations>
+			""".unformat(),
+			out.toString()
+		)
+	}
+
+	@Test fun `renderXml writes preamble without stylesheet`() {
+		val out = StringWriter()
+		out.xmlWriter().use { renderXml(it, emptyMap(), "") }
+
+		assertEquals(
+			"""
+				<?xml version="1.0" encoding="utf-8"?>
+				<violations project=""></violations>
+			""".unformat(),
+			out.toString()
+		)
+	}
+
+	@Test fun `renderXml writes project name on root`() {
+		val out = StringWriter()
+		out.xmlWriter().use { renderXml(it, emptyMap(), "project name") }
+
+		assertEquals(
+			"""
+				<?xml version="1.0" encoding="utf-8"?>
+				<violations project="project name"></violations>
+			""".unformat(),
+			out.toString()
+		)
+	}
+}
+
+private fun String.unformat() =
+	trimIndent().lines().joinToString(separator = "")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducerTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducerTest.kt
@@ -10,75 +10,41 @@ import net.twisterrob.gradle.common.grouper.Grouper.Start
 import net.twisterrob.gradle.quality.Violation
 import net.twisterrob.gradle.quality.Violations
 import org.gradle.api.Project
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.io.FileMatchers.anExistingFile
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.redundent.kotlin.xml.Node
-import org.redundent.kotlin.xml.xml
 import java.io.File
 import kotlin.reflect.jvm.javaMethod
-import kotlin.test.assertEquals
 
 class XmlProducerTest {
 
-	@Test fun `produceXml writes xml`() {
-		val robot = Robot()
+	@Test fun `produceXml writes xml`(@TempDir temp: File) {
+		val robot = Robot(
+			xmlFile = temp.resolve("output.xml"),
+			xslFile = temp.resolve("subdir").resolve("style.xsl")
+		)
 		robot.stubResult(emptyList())
 		robot.stubResultIsGrouped(emptyMap())
-		robot.stubGroupIsRendered(xml("test"))
-		robot.stubWriteXml()
-		robot.rootProjectName("don't matter")
+		robot.stubGroupIsRendered()
+		robot.stubRootProjectName("don't matter")
 
 		robot.callProduceXml()
 
 		robot.verifyXmlWritten()
 	}
 
-	@Test fun `produceXml sets project name in xml`() {
-		val robot = Robot()
-		robot.stubResult(emptyList())
-		robot.stubResultIsGrouped(emptyMap())
-		val xmlTree = xml("test")
-		robot.stubGroupIsRendered(xmlTree)
-		robot.stubWriteXml()
-		robot.rootProjectName("root project")
-
-		robot.callProduceXml()
-
-		assertEquals("root project", xmlTree.attributes["project"])
-	}
-
-	@Test fun `writeXml writes preamble`(@TempDir temp: File) {
-		val output = temp.resolve("output.xml")
-		val xsl = temp.resolve("subdir").resolve("style.xsl")
-
-		writeXml(xml("test"), output, xsl)
-
-		assertThat(output, anExistingFile())
-		assertEquals(
-			"""
-				<?xml version="1.0" encoding="utf-8"?>
-				<?xml-stylesheet type="text/xsl" href="${xsl.parentFile.name}/${xsl.name}"?>
-				<test/>
-			""".trimIndent(),
-			output.readText()
-		)
-	}
-
 	private class Robot(
-		private val xmlFile: File = File("."),
-		private val xslFile: File = File(".")
+		private val xmlFile: File,
+		private val xslFile: File
 	) {
 
 		fun callProduceXml() {
-			project.produceXml(results, xmlFile, xslFile)
+			project.produceXml(results, xmlFile.absoluteFile, xslFile.absoluteFile)
 		}
 
 		private lateinit var results: Start<Violations>
 		private lateinit var list: List<Violations>
 		private lateinit var grouped: Map<Category, Map<Reporter, List<Violation>>>
-		private lateinit var xmlTree: Node
+		private lateinit var projectName: String
 		private var project: Project = mockk()
 
 		fun stubResult(list: List<Violations>) {
@@ -93,22 +59,17 @@ class XmlProducerTest {
 			every { group(list) } returns grouped
 		}
 
-		fun stubGroupIsRendered(xmlTree: Node) {
-			this.xmlTree = xmlTree
+		fun stubGroupIsRendered() {
 			mockkStatic(::renderXml.javaMethod!!.declaringClass.name)
-			every { renderXml(grouped) } returns xmlTree
-		}
-
-		fun stubWriteXml() {
-			mockkStatic(::writeXml.javaMethod!!.declaringClass.name)
-			every { writeXml(xmlTree, xmlFile, xslFile) } just runs
+			every { renderXml(any(), grouped, any(), any()) } just runs
 		}
 
 		fun verifyXmlWritten() {
-			verify { writeXml(xmlTree, xmlFile, xslFile) }
+			verify { renderXml(any(), grouped, projectName, "${xslFile.parentFile.name}/${xslFile.name}") }
 		}
 
-		fun rootProjectName(name: String) {
+		fun stubRootProjectName(name: String) {
+			this.projectName = name
 			every { project.rootProject } returns mockk rootProject@{
 				every { this@rootProject.name } returns name
 			}

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducerTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/XmlProducerTest.kt
@@ -1,0 +1,117 @@
+package net.twisterrob.gradle.quality.report.html
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.verify
+import net.twisterrob.gradle.common.grouper.Grouper.Start
+import net.twisterrob.gradle.quality.Violation
+import net.twisterrob.gradle.quality.Violations
+import org.gradle.api.Project
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.io.FileMatchers.anExistingFile
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.redundent.kotlin.xml.Node
+import org.redundent.kotlin.xml.xml
+import java.io.File
+import kotlin.reflect.jvm.javaMethod
+import kotlin.test.assertEquals
+
+class XmlProducerTest {
+
+	@Test fun `produceXml writes xml`() {
+		val robot = Robot()
+		robot.stubResult(emptyList())
+		robot.stubResultIsGrouped(emptyMap())
+		robot.stubGroupIsRendered(xml("test"))
+		robot.stubWriteXml()
+		robot.rootProjectName("don't matter")
+
+		robot.callProduceXml()
+
+		robot.verifyXmlWritten()
+	}
+
+	@Test fun `produceXml sets project name in xml`() {
+		val robot = Robot()
+		robot.stubResult(emptyList())
+		robot.stubResultIsGrouped(emptyMap())
+		val xmlTree = xml("test")
+		robot.stubGroupIsRendered(xmlTree)
+		robot.stubWriteXml()
+		robot.rootProjectName("root project")
+
+		robot.callProduceXml()
+
+		assertEquals("root project", xmlTree.attributes["project"])
+	}
+
+	@Test fun `writeXml writes preamble`(@TempDir temp: File) {
+		val output = temp.resolve("output.xml")
+		val xsl = temp.resolve("subdir").resolve("style.xsl")
+
+		writeXml(xml("test"), output, xsl)
+
+		assertThat(output, anExistingFile())
+		assertEquals(
+			"""
+				<?xml version="1.0" encoding="utf-8"?>
+				<?xml-stylesheet type="text/xsl" href="${xsl.parentFile.name}/${xsl.name}"?>
+				<test/>
+			""".trimIndent(),
+			output.readText()
+		)
+	}
+
+	private class Robot(
+		private val xmlFile: File = File("."),
+		private val xslFile: File = File(".")
+	) {
+
+		fun callProduceXml() {
+			project.produceXml(results, xmlFile, xslFile)
+		}
+
+		private lateinit var results: Start<Violations>
+		private lateinit var list: List<Violations>
+		private lateinit var grouped: Map<Category, Map<Reporter, List<Violation>>>
+		private lateinit var xmlTree: Node
+		private var project: Project = mockk()
+
+		fun stubResult(list: List<Violations>) {
+			this.list = list
+			this.results = mockk()
+			every { results.list } returns list
+		}
+
+		fun stubResultIsGrouped(grouped: Map<Category, Map<Reporter, List<Violation>>>) {
+			this.grouped = grouped
+			mockkStatic(::group.javaMethod!!.declaringClass.name)
+			every { group(list) } returns grouped
+		}
+
+		fun stubGroupIsRendered(xmlTree: Node) {
+			this.xmlTree = xmlTree
+			mockkStatic(::renderXml.javaMethod!!.declaringClass.name)
+			every { renderXml(grouped) } returns xmlTree
+		}
+
+		fun stubWriteXml() {
+			mockkStatic(::writeXml.javaMethod!!.declaringClass.name)
+			every { writeXml(xmlTree, xmlFile, xslFile) } just runs
+		}
+
+		fun verifyXmlWritten() {
+			verify { writeXml(xmlTree, xmlFile, xslFile) }
+		}
+
+		fun rootProjectName(name: String) {
+			every { project.rootProject } returns mockk rootProject@{
+				every { this@rootProject.name } returns name
+			}
+		}
+	}
+}

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
@@ -175,7 +175,7 @@ class HtmlReportTaskTest {
 					def xml = lint.lintOptions.xmlOutput
 					xml.text = '<issues format="4" by="${HtmlReportTaskTest::class}">'
 					xml.withWriterAppend { writer ->
-						1000.times {
+						2800.times {
 						    writer.write(
 								'<issue id="MyLint" category="Performance" severity="Warning"' +
 								'       message="Fake lint" summary="Fake lint" explanation="Fake lint&#10;"' +

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
@@ -177,7 +177,7 @@ class HtmlReportTaskTest {
 					def xml = lint.lintOptions.xmlOutput
 					xml.text = '<issues format="4" by="${HtmlReportTaskTest::class}">'
 					xml.withWriterAppend { writer ->
-						2500.times {
+						2000.times {
 							writer.write(
 								'<issue id="MyLint" category="Performance" severity="Warning"' +
 								'       message="Fake lint" summary="Fake lint" explanation="Fake lint&#10;"' +

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
@@ -56,7 +56,9 @@ class HtmlReportTaskTest {
 			android.lintOptions {
 				abortOnError = false
 				//noinspection GroovyAssignabilityCheck
-				check = [${checks.joinToString(prefix = "\n\t\t", separator = ",\n\t\t", postfix = "\n\t") { "'$it'" }}]
+				check = [
+					${checks.joinToString(separator = ",\n\t\t\t\t\t") { "'$it'" }}
+				]
 			}
 		""".trimIndent()
 
@@ -81,7 +83,7 @@ class HtmlReportTaskTest {
 
 			android.lintOptions {
 				//noinspection GroovyAssignabilityCheck
-				check = ['IconXmlAndPng','UnusedResources']
+				check = ['IconXmlAndPng', 'UnusedResources']
 			}
 		""".trimIndent()
 		gradle.run(script, "lint", "htmlReport").build()
@@ -103,7 +105,7 @@ class HtmlReportTaskTest {
 
 			android.lintOptions {
 				//noinspection GroovyAssignabilityCheck
-				check = ['IconMissingDensityFolder','UnusedResources']
+				check = ['IconMissingDensityFolder', 'UnusedResources']
 			}
 		""".trimIndent()
 		gradle.run(script, "lint", "htmlReport").build()

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
@@ -177,12 +177,12 @@ class HtmlReportTaskTest {
 					def xml = lint.lintOptions.xmlOutput
 					xml.text = '<issues format="4" by="${HtmlReportTaskTest::class}">'
 					xml.withWriterAppend { writer ->
-						2800.times {
-						    writer.write(
+						2500.times {
+							writer.write(
 								'<issue id="MyLint" category="Performance" severity="Warning"' +
 								'       message="Fake lint" summary="Fake lint" explanation="Fake lint&#10;"' +
 								'       priority="3" errorLine1="foo" errorLine2="bar">' +
-	                            '    <location file="does not matter" line="' + it + '" column="0"/>' +
+								'	<location file="does not matter" line="' + it + '" column="0"/>' +
 								'</issue>'
 							)
 						}

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskUnitTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskUnitTest.kt
@@ -4,7 +4,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class HtmlReportTaskUnitTest {
@@ -14,7 +14,7 @@ class HtmlReportTaskUnitTest {
 		project.plugins.apply("reporting-base")
 		val sut = project.tasks.create("sut", HtmlReportTask::class.java)
 
-		val ex = assertThrows<Throwable> {
+		val ex = assertFailsWith<Throwable> {
 			sut.transform()
 		}
 

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskUnitTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskUnitTest.kt
@@ -1,0 +1,26 @@
+package net.twisterrob.gradle.quality.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertNotNull
+
+class HtmlReportTaskUnitTest {
+
+	@Test fun `transformation error displays affected file names`() {
+		val project = ProjectBuilder.builder().build()
+		project.plugins.apply("reporting-base")
+		val sut = project.tasks.create("sut", HtmlReportTask::class.java)
+
+		val ex = assertThrows<Throwable> {
+			sut.transform()
+		}
+
+		assertThat(ex.message, containsString(sut.xml.get().toString()))
+		assertThat(ex.message, containsString(sut.xslOutput.get().toString()))
+		assertThat(ex.message, containsString(sut.html.get().toString()))
+		assertNotNull(ex.cause)
+	}
+}


### PR DESCRIPTION
XSLT generation still uses a lot of memory, but the amount of processable data was roughly tripled with this.