### PR TITLE
JUnit 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,8 @@ allprojects {
 		}
 
 		tasks.withType<Test> {
+			useJUnitPlatform()
+
 			if (System.getProperties().containsKey("idea.paths.selector")) {
 				logger.debug("Keeping folder contents after test run from IDEA")
 				// see net.twisterrob.gradle.test.GradleRunnerRule
@@ -233,13 +235,12 @@ project.tasks.create("tests", TestReport::class.java) {
 
 publishing {
 	publications.invoke {
-		subprojects {
-			val project = this
+		subprojects.filterNot { it.name == "internal" }.forEach { project ->
 			project.name(MavenPublication::class) {
 				// compiled files: artifact(tasks["jar"])) { classifier = null } + dependencies
-				from(components["java"])
+				from(project.components["java"])
 				// source files
-				artifact(tasks["sourcesJar"]) { classifier = "sources" }
+				artifact(project.tasks["sourcesJar"]) { classifier = "sources" }
 
 				artifactId = project.base.archivesBaseName
 				version = project.version as String

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,6 @@ allprojects {
 			add("implementation", "org.jetbrains.kotlin:kotlin-reflect:${VERSION_KOTLIN}")
 
 			add("testImplementation", "org.jetbrains.kotlin:kotlin-test:${VERSION_KOTLIN}")
-			add("testImplementation", "org.jetbrains.kotlin:kotlin-test-junit:${VERSION_KOTLIN}")
 		}
 	}
 

--- a/checkers/checkstyle/build.gradle.kts
+++ b/checkers/checkstyle/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
 base.archivesBaseName = "twister-quality-checkstyle"
 
 val VERSION_ANDROID_PLUGIN: String by project
-val VERSION_JUNIT: String by project
-val VERSION_HAMCREST: String by project
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
 
 dependencies {
 	implementation(project(":common"))
@@ -16,9 +13,7 @@ dependencies {
 	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
 
 	testImplementation(project(":test"))
-	testImplementation("junit:junit:${VERSION_JUNIT}")
-	testImplementation("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
-	testImplementation("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
+	testImplementation(project(":test:internal"))
 }
 
 pullTestResourcesFrom(":test")

--- a/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
+++ b/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.common.TaskConfigurator
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.failReason
@@ -16,10 +17,11 @@ import org.hamcrest.Matchers.hasItems
 import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.startsWith
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class CheckStylePluginTest {
 
 	companion object {
@@ -27,7 +29,7 @@ class CheckStylePluginTest {
 		private val endl = System.lineSeparator()
 	}
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `does not apply to empty project`() {
 		@Language("gradle")

--- a/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTaskTest_ConfigLocation.kt
+++ b/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTaskTest_ConfigLocation.kt
@@ -1,6 +1,7 @@
 package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.failReason
 import net.twisterrob.gradle.test.runFailingBuild
@@ -9,24 +10,25 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class CheckStyleTaskTest_ConfigLocation {
 
 	companion object {
 		val CONFIG_PATH = arrayOf("config", "checkstyle", "checkstyle.xml")
 	}
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	private lateinit var noChecksConfig: String
 	private lateinit var failingConfig: String
 	private lateinit var failingContent: String
 
-	@Before fun setUp() {
+	@BeforeEach fun setUp() {
 		noChecksConfig = gradle.templateFile("checkstyle-empty.xml").readText()
 		failingConfig = gradle.templateFile("checkstyle-simple_failure.xml").readText()
 		failingContent = gradle.templateFile("checkstyle-simple_failure.xml").readText()

--- a/checkers/pmd/build.gradle.kts
+++ b/checkers/pmd/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
 base.archivesBaseName = "twister-quality-pmd"
 
 val VERSION_ANDROID_PLUGIN: String by project
-val VERSION_JUNIT: String by project
-val VERSION_HAMCREST: String by project
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
 
 dependencies {
 	implementation(project(":common"))
@@ -16,9 +13,7 @@ dependencies {
 	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
 
 	testImplementation(project(":test"))
-	testImplementation("junit:junit:${VERSION_JUNIT}")
-	testImplementation("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
-	testImplementation("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
+	testImplementation(project(":test:internal"))
 }
 
 pullTestResourcesFrom(":test")

--- a/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
+++ b/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
@@ -1,6 +1,7 @@
 package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.failReason
 import net.twisterrob.gradle.test.runBuild
@@ -14,10 +15,11 @@ import org.hamcrest.Matchers.hasItems
 import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.startsWith
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class PmdPluginTest {
 
 	companion object {
@@ -25,7 +27,7 @@ class PmdPluginTest {
 		private val endl = System.lineSeparator()
 	}
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `does not apply to empty project`() {
 		@Language("gradle")

--- a/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdTaskTest_ConfigLocation.kt
+++ b/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdTaskTest_ConfigLocation.kt
@@ -1,6 +1,7 @@
 package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.failReason
 import net.twisterrob.gradle.test.runFailingBuild
@@ -9,11 +10,12 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class PmdTaskTest_ConfigLocation {
 
 	companion object {
@@ -21,13 +23,13 @@ class PmdTaskTest_ConfigLocation {
 		val CONFIG_PATH = arrayOf("config", "pmd", "pmd.xml")
 	}
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	private lateinit var noChecksConfig: String
 	private lateinit var failingConfig: String
 	private lateinit var failingContent: String
 
-	@Before fun setUp() {
+	@BeforeEach fun setUp() {
 		noChecksConfig = gradle.templateFile("pmd-empty.xml").readText()
 		failingConfig = gradle.templateFile("pmd-simple_failure.xml").readText()
 		failingContent = gradle.templateFile("pmd-simple_failure.java").readText()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -7,8 +7,6 @@ base.archivesBaseName = "twister-quality-common"
 
 val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_JSR305_ANNOTATIONS: String by project
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
-val VERSION_JUNIT: String by project
 
 dependencies {
 	implementation(gradleApi())
@@ -16,15 +14,14 @@ dependencies {
 	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
 	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
 
-	testImplementation("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
-	testImplementation("junit:junit:${VERSION_JUNIT}")
+	testImplementation(project(":test:internal"))
 	testImplementation("com.google.guava:guava:22.0")
 }
 
 tasks.withType<JavaCompile> {
-	options.compilerArgs.addAll(listOf(
+	options.compilerArgs as MutableCollection<String> += listOf(
 		"-proc:none" // disable annotation processing (not used, hides auto-value processors being on classpath)
-	))
+	)
 }
 
 // don't double-compile Java classes

--- a/common/src/test/groovy/net/twisterrob/gradle/common/grouper/GrouperTest_Groovy.groovy
+++ b/common/src/test/groovy/net/twisterrob/gradle/common/grouper/GrouperTest_Groovy.groovy
@@ -5,14 +5,16 @@ import groovy.transform.CompileStatic
 import net.twisterrob.gradle.common.grouper.TFO.E
 import net.twisterrob.gradle.common.grouper.TFO.F
 import net.twisterrob.gradle.common.grouper.TFO.G
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 class GrouperTest_Groovy {
 
 	Grouper.Start<TFO> sut
 
-	@Before void setUp() {
+	@BeforeEach void setUp() {
 		sut = Grouper.create([ TFO.E1F1G1, TFO.E1F2G1, TFO.E2F1G2, TFO.E2F2G2 ])
 	}
 
@@ -26,8 +28,10 @@ class GrouperTest_Groovy {
 	}
 
 	@CompileDynamic
-	@Test(expected = MissingPropertyException) void missingPropertyFails() {
-		sut.aMissingName
+	@Test void missingPropertyFails() {
+		assertThrows(MissingPropertyException, {
+			sut.aMissingName
+		})
 	}
 
 	@CompileDynamic

--- a/common/src/test/java/net/twisterrob/gradle/common/UtilsTest.java
+++ b/common/src/test/java/net/twisterrob/gradle/common/UtilsTest.java
@@ -5,10 +5,11 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UtilsTest {
 
@@ -26,9 +27,11 @@ public class UtilsTest {
 				assertNull(result);
 			}
 
-			@Test(expected = NullPointerException.class) public void addValueToNullBuiltIn() {
-				@SuppressWarnings({"ConstantConditions", "unused"})
-				Integer result = VALUE + NULL;
+			@Test public void addValueToNullBuiltIn() {
+				assertThrows(NullPointerException.class, () -> {
+					@SuppressWarnings({"ConstantConditions", "unused"})
+					Integer result = VALUE + NULL;
+				});
 			}
 
 			@Test public void addValueToNull() {
@@ -37,9 +40,11 @@ public class UtilsTest {
 				assertEquals(VALUE, result);
 			}
 
-			@Test(expected = NullPointerException.class) public void addNullToValueBuiltIn() {
-				@SuppressWarnings({"ConstantConditions", "unused"})
-				Integer result = NULL + VALUE;
+			@Test public void addNullToValueBuiltIn() {
+				assertThrows(NullPointerException.class, () -> {
+					@SuppressWarnings({"ConstantConditions", "unused"})
+					Integer result = NULL + VALUE;
+				});
 			}
 
 			@Test public void addNullToValue() {

--- a/common/src/test/java/net/twisterrob/gradle/common/grouper/GrouperTest_Java.java
+++ b/common/src/test/java/net/twisterrob/gradle/common/grouper/GrouperTest_Java.java
@@ -7,9 +7,9 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/common/src/test/kotlin/net/twisterrob/gradle/common/grouper/GrouperTest.kt
+++ b/common/src/test/kotlin/net/twisterrob/gradle/common/grouper/GrouperTest.kt
@@ -1,7 +1,7 @@
 package net.twisterrob.gradle.common.grouper
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class GrouperTest {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,8 @@ VERSION_HAMCREST=2.0.0.0
 VERSION_MOCKITO=2.24.4
 # https://github.com/nhaarman/mockito-kotlin/releases
 VERSION_MOCKITO_KOTLIN=2.1.0
+# https://github.com/mockk/mockk/releases
+VERSION_MOCKK=1.9.1.kotlin12
 # https://github.com/FlexTradeUKLtd/jfixture/releases
 VERSION_JFIXTURE=2.7.2
 # https://github.com/google/guava/releases

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -7,6 +7,7 @@ base.archivesBaseName = "twister-quality"
 
 val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_VIOLATIONS: String by project
+val VERSION_XML_BUILDER: String by project
 
 dependencies {
 	implementation(project(":common"))

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -7,13 +7,6 @@ base.archivesBaseName = "twister-quality"
 
 val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_VIOLATIONS: String by project
-val VERSION_JUNIT: String by project
-val VERSION_HAMCREST: String by project
-val VERSION_MOCKITO: String by project
-val VERSION_MOCKITO_KOTLIN: String by project
-val VERSION_JFIXTURE: String by project
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
-val VERSION_XML_BUILDER: String by project
 
 dependencies {
 	implementation(project(":common"))
@@ -25,15 +18,9 @@ dependencies {
 	implementation("se.bjurr.violations:violations-lib:${VERSION_VIOLATIONS}")
 	implementation("org.redundent:kotlin-xml-builder:${VERSION_XML_BUILDER}")
 
-	testImplementation(gradleTestKit())
 	testImplementation(project(":test"))
-
-	testImplementation("junit:junit:${VERSION_JUNIT}")
-	testImplementation("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
-	testImplementation("org.mockito:mockito-core:${VERSION_MOCKITO}")
-	testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${VERSION_MOCKITO_KOTLIN}")
-	testImplementation("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
-	testImplementation("com.flextrade.jfixture:jfixture:${VERSION_JFIXTURE}")
+	testImplementation(project(":test:internal"))
+	testRuntime("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
 }
 
-listOf( ":test", ":checkstyle", ":pmd" ).forEach(project::pullTestResourcesFrom)
+listOf(":test", ":checkstyle", ":pmd").forEach(project::pullTestResourcesFrom)

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/QualityPluginTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/QualityPluginTest.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.quality
 
 import net.twisterrob.gradle.quality.tasks.GlobalLintGlobalFinalizerTask
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.runBuild
@@ -11,13 +12,14 @@ import org.hamcrest.Matchers.hasItems
 import org.hamcrest.Matchers.matchesPattern
 import org.hamcrest.Matchers.not
 import org.intellij.lang.annotations.Language
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class QualityPluginTest {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `apply violationReportConsole only on root project`() {
 		@Language("gradle")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/TableGeneratorTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/TableGeneratorTest.kt
@@ -1,7 +1,7 @@
 package net.twisterrob.gradle.quality.report
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class TableGeneratorTest {
 

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModelTest_ANDROIDLINT.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModelTest_ANDROIDLINT.kt
@@ -7,7 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
 

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTaskTest.kt
@@ -1,6 +1,7 @@
 package net.twisterrob.gradle.quality.tasks
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.runBuild
@@ -10,12 +11,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItems
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class GlobalLintGlobalFinalizerTaskTest {
-	@Rule @JvmField val gradle = GradleRunnerRule()
+
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `passes when no lint violations found`() {
 		val modules: Array<String> = arrayOf(

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
@@ -1,17 +1,19 @@
 package net.twisterrob.gradle.quality.tasks
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.runFailingBuild
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class GlobalTestFinalizerTaskTest {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `gathers results from root app`() {
 		@Language("java")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTaskTest.kt
@@ -1,22 +1,24 @@
 package net.twisterrob.gradle.quality.tasks
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.runBuild
 import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.not
 import org.hamcrest.io.FileMatchers.anExistingFile
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
 /**
  * @see HtmlReportTask
  */
+@ExtendWith(GradleRunnerRuleExtension::class)
 class HtmlReportTaskTest {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `runs on empty project`() {
 		gradle.basedOn("android-root_app")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
@@ -4,6 +4,7 @@ import net.twisterrob.gradle.common.ALL_VARIANTS_NAME
 import net.twisterrob.gradle.common.grouper.Grouper
 import net.twisterrob.gradle.quality.Violations
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.runBuild
@@ -11,11 +12,12 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.intellij.lang.annotations.Language
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.io.File
 import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class ValidateViolationsTaskTest {
 
 	companion object {
@@ -27,7 +29,7 @@ class ValidateViolationsTaskTest {
 		val VIOLATION_PATTERN = Regex("""([A-Z][a-zA-Z0-9_]+?)_(\d).java""")
 	}
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `get total violation counts on root project`() {
 		gradle.file(gradle.templateFile("checkstyle-simple_failure.java").readText(), *SOURCE_PATH, "Checkstyle.java")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
@@ -1,17 +1,19 @@
 package net.twisterrob.gradle.quality.tasks
 
 import net.twisterrob.gradle.test.GradleRunnerRule
+import net.twisterrob.gradle.test.GradleRunnerRuleExtension
 import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.runBuild
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class VersionsTaskTest {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `print missing versions`() {
 		@Language("gradle")

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ rootProject.name = "net.twisterrob.gradle"
 include(":quality")
 include(":common")
 include(":test")
+include(":test:internal")
 
 [ "checkstyle", "pmd" ].each {
 	include(":${it}")

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -6,13 +6,8 @@ plugins {
 base.archivesBaseName = "twister-gradle-test"
 
 val VERSION_JUNIT: String by project
-val VERSION_JUNIT_JUPITER: String by project
-val VERSION_MOCKITO: String by project
-val VERSION_MOCKITO_KOTLIN: String by project
-val VERSION_HAMCREST: String by project
 val VERSION_JSR305_ANNOTATIONS: String by project
 val VERSION_JETBRAINS_ANNOTATIONS: String by project
-val VERSION_LINT: String by project
 
 dependencies {
 	compileOnly(gradleApi())
@@ -25,23 +20,7 @@ dependencies {
 
 	testImplementation(gradleApi())
 	testImplementation(gradleTestKit())
-	testImplementation("junit:junit:${VERSION_JUNIT}")
-	testImplementation("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
-	testImplementation("org.junit.jupiter:junit-jupiter-migrationsupport:$VERSION_JUNIT_JUPITER")
-	testImplementation("org.junit.jupiter:junit-jupiter-params:$VERSION_JUNIT_JUPITER")
-	testRuntime("org.junit.jupiter:junit-jupiter-engine:$VERSION_JUNIT_JUPITER")
-	testRuntime("org.junit.vintage:junit-vintage-engine:$VERSION_JUNIT_JUPITER")
-	testImplementation("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
-	testImplementation("org.mockito:mockito-core:${VERSION_MOCKITO}")
-	testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${VERSION_MOCKITO_KOTLIN}")
-	testImplementation("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
-	// only here so IDEA can browse the source files of this dependency when getting a stack trace or finding usages
-	testRuntimeOnly("com.android.tools.lint:lint:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-api:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-gradle:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-gradle-api:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-checks:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-kotlin:${VERSION_LINT}") { isTransitive = false }
+	testImplementation(project(":test:internal"))
 }
 
 // Need to depend on the real artifact so TestPluginTest can work
@@ -56,13 +35,11 @@ tasks {
 	}
 }
 
-tasks.withType<Test> { useJUnitPlatform() }
-
 afterEvaluate {
 	//noinspection UnnecessaryQualifiedReference keep it explicitly together with code
 	val metaTask = tasks["pluginUnderTestMetadata"] as org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
 	metaTask.pluginClasspath = files(
-			configurations.runtimeClasspath - configurations.compileOnly,
-			jar.outputs.files.singleFile
+		configurations.runtimeClasspath - configurations.compileOnly,
+		jar.outputs.files.singleFile
 	)
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 base.archivesBaseName = "twister-gradle-test"
 
 val VERSION_JUNIT: String by project
+val VERSION_JUNIT_JUPITER: String by project
 val VERSION_JSR305_ANNOTATIONS: String by project
 val VERSION_JETBRAINS_ANNOTATIONS: String by project
 
@@ -15,6 +16,7 @@ dependencies {
 
 	implementation(project(":common"))
 	compileOnly("junit:junit:${VERSION_JUNIT}")
+	compileOnly("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
 	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
 	compileOnly("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
 

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -20,12 +20,10 @@ dependencies {
 
 	api("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
 
-	api("junit:junit:${VERSION_JUNIT}")
+	api("junit:junit:${VERSION_JUNIT}") // needed for GradleRunnerRule superclass even when using Extension
 	api("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
-	api("org.junit.jupiter:junit-jupiter-migrationsupport:$VERSION_JUNIT_JUPITER")
 	api("org.junit.jupiter:junit-jupiter-params:$VERSION_JUNIT_JUPITER")
 	runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$VERSION_JUNIT_JUPITER")
-	runtimeOnly("org.junit.vintage:junit-vintage-engine:$VERSION_JUNIT_JUPITER")
 
 	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
 

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
 
 	api("org.mockito:mockito-core:${VERSION_MOCKITO}")
+	api("org.mockito:mockito-junit-jupiter:${VERSION_MOCKITO}")
 	api("com.nhaarman.mockitokotlin2:mockito-kotlin:${VERSION_MOCKITO_KOTLIN}")
 
 	api("io.mockk:mockk:${VERSION_MOCKK}")

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+	`java-library`
+}
+
+val VERSION_JUNIT: String by project
+val VERSION_JUNIT_JUPITER: String by project
+val VERSION_HAMCREST: String by project
+val VERSION_JFIXTURE: String by project
+
+val VERSION_MOCKITO: String by project
+val VERSION_MOCKITO_KOTLIN: String by project
+val VERSION_MOCKK: String by project
+
+val VERSION_JETBRAINS_ANNOTATIONS: String by project
+val VERSION_LINT: String by project
+
+dependencies {
+	api(gradleApi())
+	api(gradleTestKit())
+
+	api("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
+
+	api("junit:junit:${VERSION_JUNIT}")
+	api("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
+	api("org.junit.jupiter:junit-jupiter-migrationsupport:$VERSION_JUNIT_JUPITER")
+	api("org.junit.jupiter:junit-jupiter-params:$VERSION_JUNIT_JUPITER")
+	runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$VERSION_JUNIT_JUPITER")
+	runtimeOnly("org.junit.vintage:junit-vintage-engine:$VERSION_JUNIT_JUPITER")
+
+	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
+
+	api("org.mockito:mockito-core:${VERSION_MOCKITO}")
+	api("com.nhaarman.mockitokotlin2:mockito-kotlin:${VERSION_MOCKITO_KOTLIN}")
+
+	api("io.mockk:mockk:${VERSION_MOCKK}")
+
+	api("com.flextrade.jfixture:jfixture:${VERSION_JFIXTURE}")
+
+	// TODO use buildSrc sourceOnly configuration
+	// only here so IDEA can browse the source files of this dependency when getting a stack trace or finding usages
+	testRuntimeOnly("com.android.tools.lint:lint:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly("com.android.tools.lint:lint-api:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly("com.android.tools.lint:lint-gradle:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly("com.android.tools.lint:lint-gradle-api:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly("com.android.tools.lint:lint-checks:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly("com.android.tools.lint:lint-kotlin:${VERSION_LINT}") { isTransitive = false }
+}

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRule.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRule.kt
@@ -66,19 +66,28 @@ open class GradleRunnerRule : TestRule {
 			override fun evaluate() {
 				var success = false
 				try {
-					temp.create()
-					setUp()
+					before()
 					base.evaluate()
 					success = true
 				} finally {
-					tearDown()
-					if ((success && needClearAfterSuccess) || (!success && needClearAfterFailure)) {
-						temp.delete()
-					}
+					after(success)
 				}
 			}
 		}
 	}
+
+	internal fun before() {
+		temp.create()
+		setUp()
+	}
+
+	internal fun after(success: Boolean) {
+		tearDown()
+		if ((success && needClearAfterSuccess) || (!success && needClearAfterFailure)) {
+			temp.delete()
+		}
+	}
+
 	//endregion
 
 	//region GradleRunner wrapper

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
@@ -1,0 +1,28 @@
+package net.twisterrob.gradle.test
+
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestInstancePostProcessor
+
+open class GradleRunnerRuleExtension : TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
+
+	private val rule = GradleRunnerRule()
+
+	override fun postProcessTestInstance(testInstance: Any, context: ExtensionContext) {
+		testInstance
+			.javaClass
+			.declaredFields
+			.filter { it.type === GradleRunnerRule::class.java }
+			.onEach { it.isAccessible = true }
+			.forEach { field -> field.set(testInstance, rule) }
+	}
+
+	override fun beforeEach(context: ExtensionContext) {
+		rule.before()
+	}
+
+	override fun afterEach(context: ExtensionContext) {
+		rule.after(!context.executionException.isPresent)
+	}
+}

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/BuildResultExtensionsTest.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/BuildResultExtensionsTest.kt
@@ -1,13 +1,15 @@
 package net.twisterrob.gradle.test
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.gradle.testkit.runner.BuildResult
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
+import org.mockito.junit.jupiter.MockitoExtension
 import kotlin.test.assertEquals
 
+@ExtendWith(MockitoExtension::class)
 class BuildResultExtensionsTest {
 
 	companion object {
@@ -42,8 +44,7 @@ class BuildResultExtensionsTest {
 	@Mock lateinit var mockResult: BuildResult
 
 	@BeforeEach fun setUp() {
-		MockitoAnnotations.initMocks(this)
-		`when`(mockResult.output).thenReturn(SAMPLE_OUTPUT)
+		whenever(mockResult.output).thenReturn(SAMPLE_OUTPUT)
 	}
 
 	@Test fun failReason() {

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/BuildResultExtensionsTest.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/BuildResultExtensionsTest.kt
@@ -1,12 +1,12 @@
 package net.twisterrob.gradle.test
 
 import org.gradle.testkit.runner.BuildResult
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import kotlin.test.assertEquals
 
 class BuildResultExtensionsTest {
 
@@ -41,7 +41,7 @@ class BuildResultExtensionsTest {
 
 	@Mock lateinit var mockResult: BuildResult
 
-	@Before fun setUp() {
+	@BeforeEach fun setUp() {
 		MockitoAnnotations.initMocks(this)
 		`when`(mockResult.output).thenReturn(SAMPLE_OUTPUT)
 	}

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleTest_clearAfter.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleTest_clearAfter.kt
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.junit.rules.TestRule
 import org.junit.runners.model.Statement
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class GradleRunnerRuleTest_clearAfter {
@@ -154,7 +154,7 @@ class GradleRunnerRuleTest_clearAfter {
 		}
 
 		@Test fun `clearAfterFailure triggers by default`() {
-			assertThrows<SimulatedTestFailure> {
+			assertFailsWith<SimulatedTestFailure> {
 				sut.evaluate()
 			}
 
@@ -164,7 +164,7 @@ class GradleRunnerRuleTest_clearAfter {
 		@Test fun `clearAfterFailure triggers when null`() {
 			gradle.clearAfterFailure = null
 
-			assertThrows<SimulatedTestFailure> {
+			assertFailsWith<SimulatedTestFailure> {
 				sut.evaluate()
 			}
 
@@ -180,7 +180,7 @@ class GradleRunnerRuleTest_clearAfter {
 
 			@Test
 			fun `keeps project folder`() {
-				assertThrows<SimulatedTestFailure> {
+				assertFailsWith<SimulatedTestFailure> {
 					sut.evaluate()
 				}
 
@@ -204,7 +204,7 @@ class GradleRunnerRuleTest_clearAfter {
 			}
 
 			@Test fun `removes project folder`() {
-				assertThrows<SimulatedTestFailure> {
+				assertFailsWith<SimulatedTestFailure> {
 					sut.evaluate()
 				}
 
@@ -237,7 +237,7 @@ class GradleRunnerRuleTest_clearAfter {
 			@Test fun `'true' removes project folder`() {
 				clearAfterFailureProperty.set("true")
 
-				assertThrows<SimulatedTestFailure> {
+				assertFailsWith<SimulatedTestFailure> {
 					sut.evaluate()
 				}
 
@@ -247,7 +247,7 @@ class GradleRunnerRuleTest_clearAfter {
 			@Test fun `'false' keeps project folder`() {
 				clearAfterFailureProperty.set("false")
 
-				assertThrows<SimulatedTestFailure> {
+				assertFailsWith<SimulatedTestFailure> {
 					sut.evaluate()
 				}
 

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleTest_usage.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleTest_usage.kt
@@ -4,16 +4,16 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.intellij.lang.annotations.Language
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class GradleRunnerRuleTest_usage {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
-	@Rule @JvmField val temp = TemporaryFolder()
+	private lateinit var gradle: GradleRunnerRule
 
 	@Test fun `gradle script test`() {
 		@Language("gradle")
@@ -74,9 +74,9 @@ class GradleRunnerRuleTest_usage {
 		assertThat(result.output, containsString(configFileContents))
 	}
 
-	@Test fun `buildFile from multiple basedOn merged into one including script`() {
+	@Test fun `buildFile from multiple basedOn merged into one including script`(@TempDir temp:File) {
 		fun generateFolder(name: String): File {
-			val folder = temp.newFolder("base_$name")
+			val folder = temp.resolve("base_$name").also { it.mkdirs() }
 			folder
 				.resolve("build.gradle")
 				.writeText("""println("basedOn($name)")${System.lineSeparator()}""")

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/TestPluginTest.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/TestPluginTest.kt
@@ -2,13 +2,14 @@ package net.twisterrob.gradle.test
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 
+@ExtendWith(GradleRunnerRuleExtension::class)
 class TestPluginTest {
 
-	@Rule @JvmField val gradle = GradleRunnerRule()
+	private lateinit var gradle: GradleRunnerRule
 
 	/**
 	 * Set up a full Gradle project in a test that has a test to test the plugin that helps testing Gradle.


### PR DESCRIPTION
From here on:
 * Java: pure JUnit Jupiter
 * Kotlin: JUnit Jupiter annotations + Kotlin Test assertions

Added extension to wrap the rule so the tests continue working, #67 will finalize this change.