### PR TITLE
Extract version numbers to buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import Libs.Kotlin.replaceKotlinJre7WithJdk7
+import Libs.Kotlin.replaceKotlinJre8WithJdk8
 import com.jfrog.bintray.gradle.BintrayExtension
 import groovy.util.Node
 import groovy.util.NodeList
@@ -19,8 +21,6 @@ plugins {
 
 val VERSION: String by project
 val VERSION_JAVA: String by project
-val VERSION_KOTLIN: String by project
-val VERSION_KOTLIN_DSL: String by project
 
 group = rootProject.name
 description = "Quality plugin for Gradle that supports Android flavors."
@@ -52,23 +52,18 @@ subprojects {
 allprojects {
 
 	configurations.all {
+		replaceKotlinJre7WithJdk7()
+		replaceKotlinJre8WithJdk8()
 		resolutionStrategy {
-			eachDependency {
-				if (requested.group == "org.jetbrains.kotlin") {
-					because("https://issuetracker.google.com/issues/72274424")
-					when (requested.name) {
-						"kotlin-stdlib-jre7" -> useTarget("${target.group}:kotlin-stdlib-jdk7:${target.version}")
-						"kotlin-stdlib-jre8" -> useTarget("${target.group}:kotlin-stdlib-jdk8:${target.version}")
-					}
-				}
-			}
 			// make sure we don't have many versions of Kotlin lying around
-			force("org.jetbrains.kotlin:kotlin-stdlib:${VERSION_KOTLIN}")
-			force("org.jetbrains.kotlin:kotlin-reflect:${VERSION_KOTLIN}")
-			force("org.jetbrains.kotlin:kotlin-stdlib-jre7:${VERSION_KOTLIN}")
-			force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${VERSION_KOTLIN}")
-			force("org.jetbrains.kotlin:kotlin-stdlib-jre8:${VERSION_KOTLIN}")
-			force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${VERSION_KOTLIN}")
+			force(Libs.Kotlin.stdlib)
+			force(Libs.Kotlin.reflect)
+			@Suppress("DEPRECATION") // force version so that it's upgraded correctly with useTarget
+			force(Libs.Kotlin.stdlibJre7)
+			force(Libs.Kotlin.stdlibJdk7)
+			@Suppress("DEPRECATION") // force version so that it's upgraded correctly with useTarget
+			force(Libs.Kotlin.stdlibJre8)
+			force(Libs.Kotlin.stdlibJdk8)
 		}
 	}
 
@@ -136,14 +131,14 @@ allprojects {
 	plugins.withId("kotlin") {
 		dependencies {
 			//add("implementation", "org.funktionale:funktionale-partials:1.2")
-			add("compileOnly", "org.gradle:gradle-kotlin-dsl:${VERSION_KOTLIN_DSL}") {
+			add("compileOnly", Libs.Kotlin.dsl) {
 				isTransitive = false // make sure to not pull in kotlin-compiler-embeddable
 			}
-			add("implementation", "org.jetbrains.kotlin:kotlin-stdlib:${VERSION_KOTLIN}")
-			add("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${VERSION_KOTLIN}")
-			add("implementation", "org.jetbrains.kotlin:kotlin-reflect:${VERSION_KOTLIN}")
+			add("implementation", Libs.Kotlin.stdlib)
+			add("implementation", Libs.Kotlin.stdlibJdk8)
+			add("implementation", Libs.Kotlin.reflect)
 
-			add("testImplementation", "org.jetbrains.kotlin:kotlin-test:${VERSION_KOTLIN}")
+			add("testImplementation", Libs.Kotlin.test)
 		}
 	}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ subprojects {
 
 	tasks {
 		register<Jar>("sourcesJar") {
-			classifier = "sources"
+			archiveClassifier.set("sources")
 			from(java.sourceSets["main"].kotlin.sourceDirectories)
 		}
 	}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ allprojects {
 		tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 			kotlinOptions.verbose = true
 			kotlinOptions.jvmTarget = JavaVersion.toVersion(VERSION_JAVA).toString()
-//			kotlinOptions.allWarningsAsErrors = true
+			kotlinOptions.allWarningsAsErrors = true
 		}
 
 		tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
 }
 
 val VERSION: String by project
-val VERSION_JAVA: String by project
 
 group = rootProject.name
 description = "Quality plugin for Gradle that supports Android flavors."
@@ -87,7 +86,7 @@ allprojects {
 		}
 		tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 			kotlinOptions.verbose = true
-			kotlinOptions.jvmTarget = JavaVersion.toVersion(VERSION_JAVA).toString()
+			kotlinOptions.jvmTarget = Libs.javaVersion.toString()
 			kotlinOptions.allWarningsAsErrors = true
 		}
 
@@ -144,8 +143,8 @@ allprojects {
 
 	plugins.withId("java") {
 		val java = convention.getPluginByName<JavaPluginConvention>("java")
-		java.sourceCompatibility = JavaVersion.toVersion(VERSION_JAVA)
-		java.targetCompatibility = JavaVersion.toVersion(VERSION_JAVA)
+		java.sourceCompatibility = Libs.javaVersion
+		java.targetCompatibility = Libs.javaVersion
 		(tasks["test"] as Test).testLogging.events("passed", "skipped", "failed")
 		afterEvaluate {
 			with(tasks["jar"] as Jar) {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -38,6 +38,27 @@ object Libs {
 		const val JUnit5 = "5.4.0"
 	}
 
+	object Annotations {
+
+		private const val versionJsr305 = "3.0.2"
+
+		/**
+		 * @see <a href="https://github.com/JetBrains/java-annotations">Repository</a>
+		 * @see <a href="http://repo1.maven.org/maven2/org/jetbrains/annotations/">Artifacts</a>
+		 */
+		private const val versionJetbrains = "17.0.0"
+
+		/**
+		 * <a href="https://jcp.org/en/jsr/detail?id=305">JSR 305: Annotations for Software Defect Detection</a>
+		 */
+		const val jsr305 = "com.google.code.findbugs:jsr305:${versionJsr305}"
+
+		/**
+		 * @see <a href="https://www.jetbrains.com/help/idea/annotating-source-code.html">Documentation</a>
+		 */
+		const val jetbrains = "org.jetbrains:annotations:${versionJetbrains}"
+	}
+
 	object Android {
 		const val plugin = "com.android.tools.build:gradle:${Versions.AndroidGradlePlugin}"
 	}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -30,19 +30,26 @@ object Libs {
 
 	object Android {
 		/**
-		 * @see AndroidLint which is affected by this
+		 * @see versionLint which is affected by this
 		 */
-		private const val AndroidGradlePlugin = "3.5.3"
+		private const val versionAndroidGradlePlugin = "3.5.3"
 
 		/**
+		 * = 23.0.0 + [versionAndroidGradlePlugin].
+		 *
 		 * @see com.android.build.gradle.BasePlugin.createLintClasspathConfiguration
 		 * @see `builder-model//version.properties`
-		 * @see VERSION_LINT in `gradle.properties`
 		 */
 		@Suppress("KDocUnresolvedReference")
-		private const val AndroidLint = "26.5.3"
+		private const val versionLint = "26.5.3"
 
-		const val plugin = "com.android.tools.build:gradle:${AndroidGradlePlugin}"
+		const val plugin = "com.android.tools.build:gradle:${versionAndroidGradlePlugin}"
+
+		const val lint = "com.android.tools.lint:lint:${versionLint}"
+		const val lintApi = "com.android.tools.lint:lint-api:${versionLint}"
+		const val lintGradle = "com.android.tools.lint:lint-gradle:${versionLint}"
+		const val lintGradleApi = "com.android.tools.lint:lint-gradle-api:${versionLint}"
+		const val lintChecks = "com.android.tools.lint:lint-checks:${versionLint}"
 	}
 
 	object Kotlin {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,54 @@
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyResolveDetails
+
+object Libs {
+	private object Versions {
+		/**
+		 * @see <a href="https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md">Changelog</a>
+		 */
+		const val Kotlin = "1.3.50"
+
+		/**
+		 * @see <a href="https://github.com/gradle/kotlin-dsl/releases">GitHub Releases</a>
+		 * @see <a href="https://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-kotlin-dsl/">Artifacts</a>
+		 */
+		const val KotlinDSL = "5.6.4"
+	}
+
+	object Kotlin {
+		const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.Kotlin}"
+		const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
+		const val test = "org.jetbrains.kotlin:kotlin-test:${Versions.Kotlin}"
+		const val stdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${Versions.Kotlin}"
+		const val stdlibJdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.Kotlin}"
+
+		const val dsl = "org.gradle:gradle-kotlin-dsl:${Versions.KotlinDSL}"
+
+		@Deprecated("Don't use directly", replaceWith = ReplaceWith("stdlibJdk7"))
+		const val stdlibJre7 = "org.jetbrains.kotlin:kotlin-stdlib-jre7:${Versions.Kotlin}"
+		@Deprecated("Don't use directly", replaceWith = ReplaceWith("stdlibJdk8"))
+		const val stdlibJre8 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${Versions.Kotlin}"
+
+		fun Configuration.replaceKotlinJre7WithJdk7() {
+			resolutionStrategy.eachDependency { replaceJreWithJdk(7) }
+		}
+
+		fun Configuration.replaceKotlinJre8WithJdk8() {
+			resolutionStrategy.eachDependency { replaceJreWithJdk(8) }
+		}
+
+		/**
+		 * @receiver `project.configurations.all { resolutionStrategy.eachDependency { ... } }`
+		 * @see <a href="http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages">Kotlin 1.2 change</a>
+		 * @see <a href="https://issuetracker.google.com/issues/72274424">Android Gradle Plugin issue</a>
+		 */
+		private fun DependencyResolveDetails.replaceJreWithJdk(version: Int) {
+			if (requested.group == "org.jetbrains.kotlin") {
+				because("http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages")
+				when (requested.name) {
+					"kotlin-stdlib-jre$version" -> useTarget("${target.group}:kotlin-stdlib-jdk$version:${target.version}")
+				}
+			}
+		}
+	}
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,6 +13,23 @@ object Libs {
 		 * @see <a href="https://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-kotlin-dsl/">Artifacts</a>
 		 */
 		const val KotlinDSL = "5.6.4"
+
+		/**
+		 * @see AndroidLint which is affected by this
+		 */
+		const val AndroidGradlePlugin = "3.5.3"
+
+		/**
+		 * @see com.android.build.gradle.BasePlugin.createLintClasspathConfiguration
+		 * @see `builder-model//version.properties`
+		 * @see VERSION_LINT in `gradle.properties`
+		 */
+		@Suppress("KDocUnresolvedReference")
+		const val AndroidLint = "26.5.3"
+	}
+
+	object Android {
+		const val plugin = "com.android.tools.build:gradle:${Versions.AndroidGradlePlugin}"
 	}
 
 	object Kotlin {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,6 @@
+import Libs.JUnit5.api
+import Libs.JUnit5.engine
+import Libs.JUnit5.vintage
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
 
@@ -26,6 +29,13 @@ object Libs {
 		 */
 		@Suppress("KDocUnresolvedReference")
 		const val AndroidLint = "26.5.3"
+
+		const val JUnit4 = "4.13"
+
+		/**
+		 * @see <a href="https://junit.org/junit5/docs/current/release-notes/index.html">Changelog</a>
+		 */
+		const val JUnit5 = "5.4.0"
 	}
 
 	object Android {
@@ -67,5 +77,27 @@ object Libs {
 				}
 			}
 		}
+	}
+
+	object JUnit4 {
+		const val library = "junit:junit:${Versions.JUnit4}"
+	}
+
+	/**
+	 * JUnit 5 = JUnit Platform ([api]) + JUnit Jupiter ([engine]) + JUnit Vintage ([vintage])
+	 */
+	object JUnit5 {
+
+		const val api = "org.junit.jupiter:junit-jupiter-api:${Versions.JUnit5}"
+		const val params = "org.junit.jupiter:junit-jupiter-params:${Versions.JUnit5}"
+		/**
+		 * `runtimeOnly` dependency, because it implements some interfaces from [api], but doesn't need to be visible to user.
+		 * @see <a href="https://junit.org/junit5/docs/current/user-guide/index.html#running-tests-build-gradle-engines-configure">Engines</a>
+		 */
+		const val engine = "org.junit.jupiter:junit-jupiter-engine:${Versions.JUnit5}"
+		/**
+		 * `runtimeOnly` dependency, because it implements some interfaces from [api], but doesn't need to be visible to user.
+		 */
+		const val vintage = "org.junit.vintage:junit-vintage-engine:${Versions.JUnit5}"
 	}
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -138,4 +138,10 @@ object Libs {
 		const val junit5 = "org.mockito:mockito-junit-jupiter:${version}"
 		const val kotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${versionMockitoKotlin}"
 	}
+
+	object Hamcrest {
+		private const val versionNew = "2.0.0.0"
+
+		const val new = "org.hamcrest:java-hamcrest:${versionNew}"
+	}
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -121,4 +121,21 @@ object Libs {
 		 */
 		const val vintage = "org.junit.vintage:junit-vintage-engine:${Versions.JUnit5}"
 	}
+
+	object Mockito {
+		/**
+		 * @see <a href="https://bintray.com/mockito/maven">Artifacts</a>
+		 * @see <a href="https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md">Changelog</a>
+		 */
+		private const val version = "2.24.4"
+
+		/**
+		 * @see <a href="https://github.com/nhaarman/mockito-kotlin/releases">GitHub releases</a>
+		 */
+		private const val versionMockitoKotlin = "2.1.0"
+
+		const val core = "org.mockito:mockito-core:${version}"
+		const val junit5 = "org.mockito:mockito-junit-jupiter:${version}"
+		const val kotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${versionMockitoKotlin}"
+	}
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,7 @@
 import Libs.JUnit5.api
 import Libs.JUnit5.engine
 import Libs.JUnit5.vintage
+import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
 
@@ -153,6 +154,8 @@ object Libs {
 		const val java = "com.flextrade.jfixture:jfixture:${version}"
 		const val kotlin = "com.flextrade.jfixture:kfixture:1.0.0"
 	}
+
+	val javaVersion = JavaVersion.VERSION_1_8
 
 	/**
 	 * @see <a href="https://github.com/mockk/mockk/releases">GitHub releases</a>

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -166,4 +166,7 @@ object Libs {
 	 */
 	private const val violationsVersion = "1.81"
 	const val violations = "se.bjurr.violations:violations-lib:${violationsVersion}"
+
+	private const val guavaVersion = "22.0"
+	const val guava = "com.google.guava:guava:${guavaVersion}"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,38 +5,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
 
 object Libs {
-	private object Versions {
-		/**
-		 * @see <a href="https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md">Changelog</a>
-		 */
-		const val Kotlin = "1.3.50"
-
-		/**
-		 * @see <a href="https://github.com/gradle/kotlin-dsl/releases">GitHub Releases</a>
-		 * @see <a href="https://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-kotlin-dsl/">Artifacts</a>
-		 */
-		const val KotlinDSL = "5.6.4"
-
-		/**
-		 * @see AndroidLint which is affected by this
-		 */
-		const val AndroidGradlePlugin = "3.5.3"
-
-		/**
-		 * @see com.android.build.gradle.BasePlugin.createLintClasspathConfiguration
-		 * @see `builder-model//version.properties`
-		 * @see VERSION_LINT in `gradle.properties`
-		 */
-		@Suppress("KDocUnresolvedReference")
-		const val AndroidLint = "26.5.3"
-
-		const val JUnit4 = "4.13"
-
-		/**
-		 * @see <a href="https://junit.org/junit5/docs/current/release-notes/index.html">Changelog</a>
-		 */
-		const val JUnit5 = "5.4.0"
-	}
 
 	object Annotations {
 
@@ -60,22 +28,46 @@ object Libs {
 	}
 
 	object Android {
-		const val plugin = "com.android.tools.build:gradle:${Versions.AndroidGradlePlugin}"
+		/**
+		 * @see AndroidLint which is affected by this
+		 */
+		private const val AndroidGradlePlugin = "3.5.3"
+
+		/**
+		 * @see com.android.build.gradle.BasePlugin.createLintClasspathConfiguration
+		 * @see `builder-model//version.properties`
+		 * @see VERSION_LINT in `gradle.properties`
+		 */
+		@Suppress("KDocUnresolvedReference")
+		private const val AndroidLint = "26.5.3"
+
+		const val plugin = "com.android.tools.build:gradle:${AndroidGradlePlugin}"
 	}
 
 	object Kotlin {
-		const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.Kotlin}"
-		const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
-		const val test = "org.jetbrains.kotlin:kotlin-test:${Versions.Kotlin}"
-		const val stdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${Versions.Kotlin}"
-		const val stdlibJdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.Kotlin}"
+		/**
+		 * @see <a href="https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md">Changelog</a>
+		 */
+		private const val version = "1.3.50"
 
-		const val dsl = "org.gradle:gradle-kotlin-dsl:${Versions.KotlinDSL}"
+		/**
+		 * @see <a href="https://github.com/gradle/kotlin-dsl/releases">GitHub Releases</a>
+		 * @see <a href="https://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-kotlin-dsl/">Artifacts</a>
+		 */
+		private const val versionDSL = "5.6.4"
+
+		const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
+		const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${version}"
+		const val test = "org.jetbrains.kotlin:kotlin-test:${version}"
+		const val stdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${version}"
+		const val stdlibJdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
+
+		const val dsl = "org.gradle:gradle-kotlin-dsl:${versionDSL}"
 
 		@Deprecated("Don't use directly", replaceWith = ReplaceWith("stdlibJdk7"))
-		const val stdlibJre7 = "org.jetbrains.kotlin:kotlin-stdlib-jre7:${Versions.Kotlin}"
+		const val stdlibJre7 = "org.jetbrains.kotlin:kotlin-stdlib-jre7:${version}"
 		@Deprecated("Don't use directly", replaceWith = ReplaceWith("stdlibJdk8"))
-		const val stdlibJre8 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${Versions.Kotlin}"
+		const val stdlibJre8 = "org.jetbrains.kotlin:kotlin-stdlib-jre8:${version}"
 
 		fun Configuration.replaceKotlinJre7WithJdk7() {
 			resolutionStrategy.eachDependency { replaceJreWithJdk(7) }
@@ -101,7 +93,9 @@ object Libs {
 	}
 
 	object JUnit4 {
-		const val library = "junit:junit:${Versions.JUnit4}"
+		private const val version = "4.13"
+
+		const val library = "junit:junit:${version}"
 	}
 
 	/**
@@ -109,17 +103,22 @@ object Libs {
 	 */
 	object JUnit5 {
 
-		const val api = "org.junit.jupiter:junit-jupiter-api:${Versions.JUnit5}"
-		const val params = "org.junit.jupiter:junit-jupiter-params:${Versions.JUnit5}"
+		/**
+		 * @see <a href="https://junit.org/junit5/docs/current/release-notes/index.html">Changelog</a>
+		 */
+		private const val version = "5.4.0"
+
+		const val api = "org.junit.jupiter:junit-jupiter-api:${version}"
+		const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 		/**
 		 * `runtimeOnly` dependency, because it implements some interfaces from [api], but doesn't need to be visible to user.
 		 * @see <a href="https://junit.org/junit5/docs/current/user-guide/index.html#running-tests-build-gradle-engines-configure">Engines</a>
 		 */
-		const val engine = "org.junit.jupiter:junit-jupiter-engine:${Versions.JUnit5}"
+		const val engine = "org.junit.jupiter:junit-jupiter-engine:${version}"
 		/**
 		 * `runtimeOnly` dependency, because it implements some interfaces from [api], but doesn't need to be visible to user.
 		 */
-		const val vintage = "org.junit.vintage:junit-vintage-engine:${Versions.JUnit5}"
+		const val vintage = "org.junit.vintage:junit-vintage-engine:${version}"
 	}
 
 	object Mockito {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -144,4 +144,27 @@ object Libs {
 
 		const val new = "org.hamcrest:java-hamcrest:${versionNew}"
 	}
+
+	object JFixture {
+		/**
+		 * @see <a href="https://github.com/FlexTradeUKLtd/jfixture/releases">GitHub releases</a>
+		 */
+		private const val version = "2.7.2"
+
+		const val java = "com.flextrade.jfixture:jfixture:${version}"
+		const val kotlin = "com.flextrade.jfixture:kfixture:1.0.0"
+	}
+
+	/**
+	 * @see <a href="https://github.com/mockk/mockk/releases">GitHub releases</a>
+	 */
+	private const val mockkVersion = "1.9.1.kotlin12"
+	const val mockk = "io.mockk:mockk:${mockkVersion}"
+
+	/**
+	 * @see <a href="https://github.com/tomasbjerre/violations-lib/blob/master/CHANGELOG.md">Changelog</a>
+	 * @see <a href="https://github.com/tomasbjerre/violations-lib/releases">GitHub Releases</a>
+	 */
+	private const val violationsVersion = "1.81"
+	const val violations = "se.bjurr.violations:violations-lib:${violationsVersion}"
 }

--- a/checkers/checkstyle/build.gradle.kts
+++ b/checkers/checkstyle/build.gradle.kts
@@ -5,12 +5,10 @@ plugins {
 
 base.archivesBaseName = "twister-quality-checkstyle"
 
-val VERSION_ANDROID_PLUGIN: String by project
-
 dependencies {
 	implementation(project(":common"))
 
-	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
+	compileOnly(Libs.Android.plugin)
 
 	testImplementation(project(":test"))
 	testImplementation(project(":test:internal"))

--- a/checkers/pmd/build.gradle.kts
+++ b/checkers/pmd/build.gradle.kts
@@ -5,12 +5,10 @@ plugins {
 
 base.archivesBaseName = "twister-quality-pmd"
 
-val VERSION_ANDROID_PLUGIN: String by project
-
 dependencies {
 	implementation(project(":common"))
 
-	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
+	compileOnly(Libs.Android.plugin)
 
 	testImplementation(project(":test"))
 	testImplementation(project(":test:internal"))

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,13 +5,11 @@ plugins {
 
 base.archivesBaseName = "twister-quality-common"
 
-val VERSION_JSR305_ANNOTATIONS: String by project
-
 dependencies {
 	implementation(gradleApi())
 
 	compileOnly(Libs.Android.plugin)
-	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
+	compileOnly(Libs.Annotations.jsr305)
 
 	testImplementation(project(":test:internal"))
 	testImplementation("com.google.guava:guava:22.0")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 	compileOnly(Libs.Annotations.jsr305)
 
 	testImplementation(project(":test:internal"))
-	testImplementation("com.google.guava:guava:22.0")
+	testImplementation(Libs.guava)
 }
 
 tasks.withType<JavaCompile> {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,13 +5,12 @@ plugins {
 
 base.archivesBaseName = "twister-quality-common"
 
-val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_JSR305_ANNOTATIONS: String by project
 
 dependencies {
 	implementation(gradleApi())
 
-	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
+	compileOnly(Libs.Android.plugin)
 	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
 
 	testImplementation(project(":test:internal"))

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.gradle.common
 
-import com.android.annotations.VisibleForTesting
+import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.tooling.BuildException

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.deprecation.trace=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 VERSION=0.10-SNAPSHOT
-VERSION_JAVA=1.8
 # see also AndroidLint in Versions.kt
 VERSION_LINT=26.5.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,6 @@ org.gradle.deprecation.trace=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 VERSION=0.10-SNAPSHOT
-# see also AndroidLint in Versions.kt
-VERSION_LINT=26.5.3
 
 # Default test substitutions (overridden by .travis.yml with -P)
 net.twisterrob.test.android.pluginVersion=3.5.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,13 +13,3 @@ VERSION_LINT=26.5.3
 net.twisterrob.test.android.pluginVersion=3.5.3
 net.twisterrob.test.android.compileSdkVersion=android-28
 net.twisterrob.gradle.runner.gradleVersion=5.6.4
-
-# https://github.com/mockk/mockk/releases
-VERSION_MOCKK=1.9.1.kotlin12
-# https://github.com/FlexTradeUKLtd/jfixture/releases
-VERSION_JFIXTURE=2.7.2
-# https://github.com/google/guava/releases
-VERSION_GUAVA=27.0.1-jre
-# https://github.com/tomasbjerre/violations-lib/blob/master/CHANGELOG.md
-# https://github.com/tomasbjerre/violations-lib/releases
-VERSION_VIOLATIONS=1.81

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,6 @@ net.twisterrob.test.android.pluginVersion=3.5.3
 net.twisterrob.test.android.compileSdkVersion=android-28
 net.twisterrob.gradle.runner.gradleVersion=5.6.4
 
-VERSION_JSR305_ANNOTATIONS=3.0.2
-# https://mvnrepository.com/artifact/org.jetbrains/annotations
-VERSION_JETBRAINS_ANNOTATIONS=17.0.0
 VERSION_HAMCREST=2.0.0.0
 # https://bintray.com/mockito/maven
 # https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,6 @@ net.twisterrob.test.android.compileSdkVersion=android-28
 net.twisterrob.gradle.runner.gradleVersion=5.6.4
 
 VERSION_HAMCREST=2.0.0.0
-# https://bintray.com/mockito/maven
-# https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md
-VERSION_MOCKITO=2.24.4
-# https://github.com/nhaarman/mockito-kotlin/releases
-VERSION_MOCKITO_KOTLIN=2.1.0
 # https://github.com/mockk/mockk/releases
 VERSION_MOCKK=1.9.1.kotlin12
 # https://github.com/FlexTradeUKLtd/jfixture/releases

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ net.twisterrob.test.android.pluginVersion=3.5.3
 net.twisterrob.test.android.compileSdkVersion=android-28
 net.twisterrob.gradle.runner.gradleVersion=5.6.4
 
-VERSION_HAMCREST=2.0.0.0
 # https://github.com/mockk/mockk/releases
 VERSION_MOCKK=1.9.1.kotlin12
 # https://github.com/FlexTradeUKLtd/jfixture/releases

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,6 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 VERSION=0.10-SNAPSHOT
 VERSION_JAVA=1.8
-# https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md
-VERSION_KOTLIN=1.3.50
-# https://github.com/gradle/kotlin-dsl/releases
-# https://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-kotlin-dsl/
-VERSION_KOTLIN_DSL=5.6.4
 # affects VERSION_LINT!
 VERSION_ANDROID_PLUGIN=3.5.3
 # based on com.android.build.gradle.BasePlugin.createLintClasspathConfiguration + builder-model//version.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,6 @@ net.twisterrob.gradle.runner.gradleVersion=5.6.4
 VERSION_JSR305_ANNOTATIONS=3.0.2
 # https://mvnrepository.com/artifact/org.jetbrains/annotations
 VERSION_JETBRAINS_ANNOTATIONS=17.0.0
-VERSION_JUNIT=4.13-beta-2
-# https://junit.org/junit5/docs/5.4.0/release-notes/
-VERSION_JUNIT_JUPITER=5.4.0
 VERSION_HAMCREST=2.0.0.0
 # https://bintray.com/mockito/maven
 # https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 VERSION=0.10-SNAPSHOT
 VERSION_JAVA=1.8
-# affects VERSION_LINT!
-VERSION_ANDROID_PLUGIN=3.5.3
-# based on com.android.build.gradle.BasePlugin.createLintClasspathConfiguration + builder-model//version.properties
+# see also AndroidLint in Versions.kt
 VERSION_LINT=26.5.3
 
 # Default test substitutions (overridden by .travis.yml with -P)

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 base.archivesBaseName = "twister-quality"
 
-val VERSION_ANDROID_PLUGIN: String by project
 val VERSION_VIOLATIONS: String by project
 
 dependencies {
@@ -13,13 +12,13 @@ dependencies {
 	implementation(project(":checkstyle"))
 	implementation(project(":pmd"))
 
-	compileOnly("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
+	compileOnly(Libs.Android.plugin)
 //	compileOnly ("de.aaschmid:gradle-cpd-plugin:1.0")
 	implementation("se.bjurr.violations:violations-lib:${VERSION_VIOLATIONS}")
 
 	testImplementation(project(":test"))
 	testImplementation(project(":test:internal"))
-	testRuntime("com.android.tools.build:gradle:${VERSION_ANDROID_PLUGIN}")
+	testRuntime(Libs.Android.plugin)
 }
 
 listOf(":test", ":checkstyle", ":pmd").forEach(project::pullTestResourcesFrom)

--- a/quality/build.gradle.kts
+++ b/quality/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 
 base.archivesBaseName = "twister-quality"
 
-val VERSION_VIOLATIONS: String by project
-
 dependencies {
 	implementation(project(":common"))
 	implementation(project(":checkstyle"))
@@ -14,7 +12,7 @@ dependencies {
 
 	compileOnly(Libs.Android.plugin)
 //	compileOnly ("de.aaschmid:gradle-cpd-plugin:1.0")
-	implementation("se.bjurr.violations:violations-lib:${VERSION_VIOLATIONS}")
+	implementation(Libs.violations)
 
 	testImplementation(project(":test"))
 	testImplementation(project(":test:internal"))

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRenderer.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/ViolationsRenderer.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.gradle.quality.report.html
 
-import com.android.annotations.VisibleForTesting
+import com.google.common.annotations.VisibleForTesting
 import net.twisterrob.gradle.quality.Violation
 import net.twisterrob.gradle.quality.report.html.model.ContextViewModel
 import net.twisterrob.gradle.quality.report.html.model.ContextViewModel.ArchiveContext

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.gradle.quality.tasks
 
-import com.android.annotations.VisibleForTesting
+import com.google.common.annotations.VisibleForTesting
 import net.twisterrob.gradle.quality.report.html.produceXml
 import org.gradle.api.Action
 import org.gradle.api.GradleException

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 
 base.archivesBaseName = "twister-gradle-test"
 
-val VERSION_JSR305_ANNOTATIONS: String by project
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
-
 dependencies {
 	compileOnly(gradleApi())
 	compileOnly(gradleTestKit())
@@ -15,8 +12,8 @@ dependencies {
 	implementation(project(":common"))
 	compileOnly(Libs.JUnit4.library)
 	compileOnly(Libs.JUnit5.api)
-	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
-	compileOnly("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
+	compileOnly(Libs.Annotations.jsr305)
+	compileOnly(Libs.Annotations.jetbrains)
 
 	testImplementation(gradleApi())
 	testImplementation(gradleTestKit())

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 
 base.archivesBaseName = "twister-gradle-test"
 
-val VERSION_JUNIT: String by project
-val VERSION_JUNIT_JUPITER: String by project
 val VERSION_JSR305_ANNOTATIONS: String by project
 val VERSION_JETBRAINS_ANNOTATIONS: String by project
 
@@ -15,8 +13,8 @@ dependencies {
 	compileOnly(gradleTestKit())
 
 	implementation(project(":common"))
-	compileOnly("junit:junit:${VERSION_JUNIT}")
-	compileOnly("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
+	compileOnly(Libs.JUnit4.library)
+	compileOnly(Libs.JUnit5.api)
 	compileOnly("com.google.code.findbugs:jsr305:${VERSION_JSR305_ANNOTATIONS}")
 	compileOnly("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
 

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
 	`java-library`
 }
 
-val VERSION_JUNIT: String by project
-val VERSION_JUNIT_JUPITER: String by project
 val VERSION_HAMCREST: String by project
 val VERSION_JFIXTURE: String by project
 
@@ -20,10 +18,10 @@ dependencies {
 
 	api("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
 
-	api("junit:junit:${VERSION_JUNIT}") // needed for GradleRunnerRule superclass even when using Extension
-	api("org.junit.jupiter:junit-jupiter-api:$VERSION_JUNIT_JUPITER")
-	api("org.junit.jupiter:junit-jupiter-params:$VERSION_JUNIT_JUPITER")
-	runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$VERSION_JUNIT_JUPITER")
+	api(Libs.JUnit4.library) // needed for GradleRunnerRule superclass even when using Extension
+	api(Libs.JUnit5.api)
+	api(Libs.JUnit5.params)
+	runtimeOnly(Libs.JUnit5.engine)
 
 	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
 

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -9,14 +9,13 @@ val VERSION_MOCKITO: String by project
 val VERSION_MOCKITO_KOTLIN: String by project
 val VERSION_MOCKK: String by project
 
-val VERSION_JETBRAINS_ANNOTATIONS: String by project
 val VERSION_LINT: String by project
 
 dependencies {
 	api(gradleApi())
 	api(gradleTestKit())
 
-	api("org.jetbrains:annotations:${VERSION_JETBRAINS_ANNOTATIONS}")
+	api(Libs.Annotations.jetbrains)
 
 	api(Libs.JUnit4.library) // needed for GradleRunnerRule superclass even when using Extension
 	api(Libs.JUnit5.api)

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 val VERSION_HAMCREST: String by project
 val VERSION_JFIXTURE: String by project
 
-val VERSION_MOCKITO: String by project
-val VERSION_MOCKITO_KOTLIN: String by project
 val VERSION_MOCKK: String by project
 
 val VERSION_LINT: String by project
@@ -24,9 +22,9 @@ dependencies {
 
 	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
 
-	api("org.mockito:mockito-core:${VERSION_MOCKITO}")
-	api("org.mockito:mockito-junit-jupiter:${VERSION_MOCKITO}")
-	api("com.nhaarman.mockitokotlin2:mockito-kotlin:${VERSION_MOCKITO_KOTLIN}")
+	api(Libs.Mockito.core)
+	api(Libs.Mockito.junit5)
+	api(Libs.Mockito.kotlin)
 
 	api("io.mockk:mockk:${VERSION_MOCKK}")
 

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
 	`java-library`
 }
 
-val VERSION_LINT: String by project
-
 dependencies {
 	api(gradleApi())
 	api(gradleTestKit())
@@ -27,9 +25,9 @@ dependencies {
 
 	// TODO use buildSrc sourceOnly configuration
 	// only here so IDEA can browse the source files of this dependency when getting a stack trace or finding usages
-	testRuntimeOnly("com.android.tools.lint:lint:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-api:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-gradle:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-gradle-api:${VERSION_LINT}") { isTransitive = false }
-	testRuntimeOnly("com.android.tools.lint:lint-checks:${VERSION_LINT}") { isTransitive = false }
+	testRuntimeOnly(Libs.Android.lint) { isTransitive = false }
+	testRuntimeOnly(Libs.Android.lintApi) { isTransitive = false }
+	testRuntimeOnly(Libs.Android.lintGradle) { isTransitive = false }
+	testRuntimeOnly(Libs.Android.lintGradleApi) { isTransitive = false }
+	testRuntimeOnly(Libs.Android.lintChecks) { isTransitive = false }
 }

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
 	`java-library`
 }
 
-val VERSION_HAMCREST: String by project
 val VERSION_JFIXTURE: String by project
 
 val VERSION_MOCKK: String by project
@@ -20,7 +19,7 @@ dependencies {
 	api(Libs.JUnit5.params)
 	runtimeOnly(Libs.JUnit5.engine)
 
-	api("org.hamcrest:java-hamcrest:${VERSION_HAMCREST}")
+	api(Libs.Hamcrest.new)
 
 	api(Libs.Mockito.core)
 	api(Libs.Mockito.junit5)

--- a/test/internal/build.gradle.kts
+++ b/test/internal/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
 	`java-library`
 }
 
-val VERSION_JFIXTURE: String by project
-
-val VERSION_MOCKK: String by project
-
 val VERSION_LINT: String by project
 
 dependencies {
@@ -25,9 +21,9 @@ dependencies {
 	api(Libs.Mockito.junit5)
 	api(Libs.Mockito.kotlin)
 
-	api("io.mockk:mockk:${VERSION_MOCKK}")
+	api(Libs.mockk)
 
-	api("com.flextrade.jfixture:jfixture:${VERSION_JFIXTURE}")
+	api(Libs.JFixture.java)
 
 	// TODO use buildSrc sourceOnly configuration
 	// only here so IDEA can browse the source files of this dependency when getting a stack trace or finding usages


### PR DESCRIPTION
 * Enable strict compilation for Kotlin  
    Replace deprecated VisibleForTesting annotations
 * Fix a Gradle 5.1 deprecation