### PR TITLE
Fix #85: task validation problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,19 @@
 
 ## 0.10 *(2020-01-12 --- )*
 
+### Breaking
+ * `ValidateViolationsTask.action` is removed, override `processViolations` instead (#85).
+
 ### New
  * Gradle 5 compatible (up to 5.6.4) (#84)
  * Use Gradle 5.6.4 to build (#84)
  * Use Kotlin DSL 5.6.4 (#84)
- * Android Gradle Plugin 3.5.3 compatible (#85)
+ * Android Gradle Plugin 3.5.3 compatible (#86)
 
-## Fixes
+### Fixes
  * Make sure nothing is logged when lint task is disabled.
+ 
+### Internal
  * Gradle validateTaskProperties issues (#85).
 
 ## 0.9 *(2019-02-19 --- 2019-07-11)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Fixes
  * Make sure nothing is logged when lint task is disabled.
-
+ * Gradle validateTaskProperties issues (#85).
 
 ## 0.9 *(2019-02-19 --- 2019-07-11)*
 

--- a/README.md
+++ b/README.md
@@ -37,26 +37,6 @@ There's a built-in console report that gathers all the results from all the modu
 gradlew violationReportConsole
 ```
 
-### Customizable violation report
-The action executed on the gathered reports can be customized in a Gradle script, for example:
-```groovy
-// The below code is the default behavior for `violationReportConsole`.
-// It is a good example to base customized output on.
-project.tasks.register("printViolationCounts", net.twisterrob.gradle.quality.tasks.ValidateViolationsTask) {
-	action = { net.twisterrob.gradle.common.grouper.Grouper.Start<net.twisterrob.gradle.quality.Violations> results ->
-		results.by.parser.module.variant.group().each { checker, byModule ->
-			println "\t${checker}"
-			byModule.each {module, byVariant ->
-				println "\t\t${module}:"
-				byVariant.each {variant, violations ->
-					println "\t\t\t${variant}: ${violations.size()}"
-				}
-			}
-		}
-	}
-}
-```
-
 ### Root project test report
 Gathers results from submodules and fails if there were errors.
 ```groovy

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
@@ -1,6 +1,8 @@
 package net.twisterrob.gradle.quality.tasks
 
 import com.google.common.annotations.VisibleForTesting
+import net.twisterrob.gradle.common.grouper.Grouper
+import net.twisterrob.gradle.quality.Violations
 import net.twisterrob.gradle.quality.report.html.produceXml
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -66,10 +68,11 @@ open class HtmlReportTask : ValidateViolationsTask() {
 				}
 			}
 		}
-		action = Action {
-			project.produceXml(it, xmlFile, xslOutputFile)
-		}
 		doLast { transform() }
+	}
+
+	override fun processViolations(violations: Grouper.Start<Violations>) {
+		project.produceXml(violations, xmlFile, xslOutputFile)
 	}
 
 	@VisibleForTesting

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
@@ -22,28 +22,28 @@ import javax.xml.transform.stream.StreamSource
 
 open class HtmlReportTask : ValidateViolationsTask() {
 
-	private val xmlFile get() = xml.asFile.get()
+	private val xmlFile: File get() = xml.asFile.get()
 	@OutputFile
-	var xml: RegularFileProperty = reportDir().file("violations.xml").asProperty()
+	val xml: RegularFileProperty = reportDir().file("violations.xml").asProperty()
 
-	private val htmlFile get() = html.asFile.get()
+	private val htmlFile: File get() = html.asFile.get()
 	@OutputFile
-	var html: RegularFileProperty = reportDir().file("violations.html").asProperty()
+	val html: RegularFileProperty = reportDir().file("violations.html").asProperty()
 
 	private val xslTemplateFile: File? get() = xslTemplate.asFile.orNull
 	@InputFile
 	@get:Optional
-	var xslTemplate: RegularFileProperty = project.fileProperty().apply {
+	val xslTemplate: RegularFileProperty = project.fileProperty().apply {
 		//set(project.file("config/violations.xsl"))
 	}
 
-	private val xslOutputFile get() = xslOutput.asFile.get()
+	private val xslOutputFile: File get() = xslOutput.asFile.get()
 	/**
 	 * val xslOutput: File = xml.parentFile.resolve(xslTemplate.name)
 	 */
 	// TODO @InputFile as well? maybe separate task? or task steps API?
 	@OutputFile
-	var xslOutput: RegularFileProperty = xml
+	val xslOutput: RegularFileProperty = xml
 		.map { regular ->
 			regular.asFileProvider()
 				.map { file -> file.parentFile.resolve(xslTemplateFile?.name ?: "violations.xsl") }

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
@@ -42,12 +42,7 @@ class ValidateViolationsTaskTest {
 			apply plugin: 'net.twisterrob.checkstyle'
 			apply plugin: 'net.twisterrob.pmd'
 
-			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {/*${Grouper.Start::class.java.name}<${Violations::class.java.name}>*/ results ->
-					def count = results.list.sum(0) { /*${Violations::class.java.name}*/ result -> result.violations?.size() ?: 0 }
-					println "Violations: ${'$'}{count}"
-				}
-			}
+			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name})
 		""".trimIndent()
 
 		val result = gradle.runBuild {
@@ -56,7 +51,7 @@ class ValidateViolationsTaskTest {
 		}
 
 		// TODO find another CheckStyle violation that's more specific
-		result.assertHasOutputLine("Violations: 3")
+		result.assertHasOutputLine("Summary\t(total: 3)\t         2\t  1")
 	}
 
 	@Test fun `get total violation counts`() {
@@ -71,12 +66,7 @@ class ValidateViolationsTaskTest {
 				apply plugin: 'net.twisterrob.checkstyle'
 				apply plugin: 'net.twisterrob.pmd'
 			}
-			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {/*${Grouper.Start::class.java.name}<${Violations::class.java.name}>*/ results ->
-					def count = results.list.sum(0) { /*${Violations::class.java.name}*/ result -> result.violations?.size() ?: 0 }
-					println "Violations: ${'$'}{count}"
-				}
-			}
+			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name})
 		""".trimIndent()
 
 		val result = gradle.runBuild {
@@ -85,7 +75,7 @@ class ValidateViolationsTaskTest {
 		}
 
 		// TODO find another CheckStyle violation that's more specific
-		result.assertHasOutputLine("Violations: 3")
+		result.assertHasOutputLine("Summary\t(total: 3)\t         2\t  1")
 	}
 
 	@Test fun `get per module violation counts`() {
@@ -111,18 +101,7 @@ class ValidateViolationsTaskTest {
 				apply plugin: 'com.android.library'
 				apply plugin: 'net.twisterrob.checkstyle'
 			}
-			task('printViolationCounts', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {${Grouper.Start::class.java.name}<${Violations::class.java.name}> results ->
-					results.count().by.parser.by.module.by.variant.group()['checkstyle'].each {module, byVariant ->
-						println "\t${'$'}{module}:"
-						byVariant.each {variant, resultCount ->
-							if (resultCount != null) {
-								println "\t\t${'$'}{variant}: ${'$'}{resultCount}"
-							}
-						}
-					}
-				}
-			}
+			task('printViolationCounts', type: ${ValidateViolationsTask::class.java.name})
 		""".trimIndent()
 
 		val result = gradle.runBuild {
@@ -133,13 +112,11 @@ class ValidateViolationsTaskTest {
 		assertThat(
 			result.output, containsString(
 				"""
-				:printViolationCounts
-					:EmptyBlock:
-						${ALL_VARIANTS_NAME}: 3
-					:MemberName:
-						${ALL_VARIANTS_NAME}: 2
-					:UnusedImports:
-						${ALL_VARIANTS_NAME}: 4
+				module        	variant  	checkstyle
+				:EmptyBlock   	*        	         3
+				:MemberName   	*        	         2
+				:UnusedImports	*        	         4
+				Summary       	(total: 9)	         9
 				""".trimIndent().replace(Regex("""\r?\n"""), System.lineSeparator())
 			)
 		)
@@ -155,12 +132,7 @@ class ValidateViolationsTaskTest {
 			apply plugin: 'net.twisterrob.checkstyle'
 			apply plugin: 'net.twisterrob.pmd'
 
-			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {/*${Grouper.Start::class.java.name}<${Violations::class.java.name}>*/ results ->
-					def count = results.list.sum(0) { /*${Violations::class.java.name}*/ result -> result.violations?.size() ?: 0 }
-					println "Violations: ${'$'}{count}"
-				}
-			}
+			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name})
 		""".trimIndent()
 
 		gradle.file(gradle.templateFile("checkstyle-simple_failure.java").readText(), *SOURCE_PATH, "Checkstyle.java")
@@ -180,12 +152,7 @@ class ValidateViolationsTaskTest {
 
 		@Language("gradle")
 		val script = """
-			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {/*${Grouper.Start::class.java.name}<${Violations::class.java.name}>*/ results ->
-					def count = results.list.sum(0) { /*${Violations::class.java.name}*/ result -> result.violations?.size() ?: 0 }
-					println "Violations: ${'$'}{count}"
-				}
-			}
+			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name})
 			android.lintOptions.xmlOutput = new File(buildDir, "reports/my-lint/results.xml")
 			android.lintOptions.check = ['UnusedResources']
 		""".trimIndent()
@@ -195,7 +162,7 @@ class ValidateViolationsTaskTest {
 		}
 
 		assertEquals(SUCCESS, result.task(":printViolationCount")!!.outcome)
-		result.assertHasOutputLine("Violations: 1")
+		result.assertHasOutputLine("Summary\t(total: 1)\t   1\t          0")
 	}
 
 	@Test fun `gather unique lint violations when multiple variants are linted`() {
@@ -204,12 +171,7 @@ class ValidateViolationsTaskTest {
 
 		@Language("gradle")
 		val script = """
-			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name}) {
-				action = {/*${Grouper.Start::class.java.name}<${Violations::class.java.name}>*/ results ->
-					def count = results.list.sum(0) { /*${Violations::class.java.name}*/ result -> result.violations?.size() ?: 0 }
-					println "Violations: ${'$'}{count}"
-				}
-			}
+			task('printViolationCount', type: ${ValidateViolationsTask::class.java.name})
 			android.lintOptions.check = ['UnusedResources']
 		""".trimIndent()
 
@@ -218,7 +180,7 @@ class ValidateViolationsTaskTest {
 		}
 
 		assertEquals(SUCCESS, result.task(":printViolationCount")!!.outcome)
-		result.assertHasOutputLine("Violations: 1")
+		result.assertHasOutputLine("Summary\t(total: 1)\t   1\t          0")
 	}
 
 	@Test fun `do not gather non-existent reports`() {


### PR DESCRIPTION
Fixes #85

Decided to remove `ValidateViolationsTask.action`, so `printViolationCounts` output is no longer customizable from DSL unless a task is inherited from and `processViolations` is overridden.