### PR TITLE
Use File.listFiles properly

### DIFF
--- a/common/src/main/kotlin/net/twisterrob/gradle/common/Utils.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/Utils.kt
@@ -33,6 +33,19 @@ fun <T> nullSafeSum(mapper: Function<T?, Int?>): Collector<T?, *, Int?> {
 	return Collectors.reducing(null, mapper, BinaryOperator(::safeAdd))
 }
 
+fun File.listFilesInDirectory(filter: ((File) -> Boolean)? = null): Array<File> {
+	val listFiles: Array<File>? =
+		if (filter != null)
+			this.listFiles(filter)
+		else
+			this.listFiles()
+
+	return listFiles ?: error(
+		"$this does not denote a directory or an error occurred" +
+				"\nisDirectory=${this.isDirectory}, exists=${this.exists()}, canRead=${this.canRead()}"
+	)
+}
+
 val Task.wasLaunchedOnly: Boolean
 	get() = project.gradle.startParameter.taskNames == listOf(path)
 

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/gather/TestReportGatherer.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/gather/TestReportGatherer.kt
@@ -1,5 +1,6 @@
 package net.twisterrob.gradle.quality.gather
 
+import net.twisterrob.gradle.common.listFilesInDirectory
 import net.twisterrob.gradle.quality.parsers.JUnitParser
 import org.gradle.api.tasks.testing.Test
 import se.bjurr.violations.lib.model.Violation
@@ -24,7 +25,6 @@ class TestReportGatherer<T>(
 
 	override fun findViolations(report: File): List<Violation> =
 			report
-					.listFiles({ file -> file.isFile })
-					.orEmpty()
+					.listFilesInDirectory(File::isFile)
 					.flatMap { file -> parser.parseReportOutput(file.readText()) }
 }

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/gather/TestReportGatherer.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/gather/TestReportGatherer.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.quality.gather
 
 import net.twisterrob.gradle.quality.parsers.JUnitParser
 import org.gradle.api.tasks.testing.Test
+import se.bjurr.violations.lib.model.Violation
 import se.bjurr.violations.lib.parsers.ViolationsParser
 import java.io.File
 
@@ -21,8 +22,9 @@ class TestReportGatherer<T>(
 	override fun getName(task: T): String =
 			task.path
 
-	override fun findViolations(report: File) =
+	override fun findViolations(report: File): List<Violation> =
 			report
 					.listFiles({ file -> file.isFile })
+					.orEmpty()
 					.flatMap { file -> parser.parseReportOutput(file.readText()) }
 }

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
@@ -1,5 +1,6 @@
 package net.twisterrob.gradle.quality.report.html.model
 
+import net.twisterrob.gradle.common.listFilesInDirectory
 import net.twisterrob.gradle.quality.Violation
 import java.io.File
 import java.io.PrintWriter
@@ -99,13 +100,12 @@ sealed class ContextViewModel {
 			fun <E> Iterable<E>.replace(old: E, new: E) = map { if (it == old) new else it }
 			fun Array<File>.sorted() = sortedWith(compareBy<File> { !it.isDirectory }.thenBy { it.name })
 			val dir = v.location.file
-			val contents = dir.listFiles()
-				.orEmpty()
+			val contents = dir.listFilesInDirectory()
 				.sorted()
 				.joinToString("\n") { it.name }
 				.prependIndent("\t")
 			val dirWithContents = dir.name + ":\n" + contents
-			val siblings = dir.parentFile.listFiles().orEmpty().sorted().map { it.name }
+			val siblings = dir.parentFile.listFilesInDirectory().sorted().map { it.name }
 			val relevantListing = siblings
 				.replace(dir.name, dirWithContents)
 				.joinToString("\n")

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/ContextViewModel.kt
@@ -100,11 +100,12 @@ sealed class ContextViewModel {
 			fun Array<File>.sorted() = sortedWith(compareBy<File> { !it.isDirectory }.thenBy { it.name })
 			val dir = v.location.file
 			val contents = dir.listFiles()
+				.orEmpty()
 				.sorted()
 				.joinToString("\n") { it.name }
 				.prependIndent("\t")
 			val dirWithContents = dir.name + ":\n" + contents
-			val siblings = dir.parentFile.listFiles().sorted().map { it.name }
+			val siblings = dir.parentFile.listFiles().orEmpty().sorted().map { it.name }
 			val relevantListing = siblings
 				.replace(dir.name, dirWithContents)
 				.joinToString("\n")

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
@@ -91,7 +91,7 @@ class ValidateViolationsTaskTest {
 	@Test fun `get per module violation counts`() {
 		val template = gradle.templateFile("checkstyle-multiple_violations/checkstyle-template.xml").readText()
 		val dir = gradle.templateFile("checkstyle-multiple_violations")
-		dir.listFiles().sorted().forEach { file: File ->
+		dir.listFiles().orEmpty().sorted().forEach { file: File ->
 			println("Building module from ${file}")
 			VIOLATION_PATTERN.matchEntire(file.name)?.apply {
 				val checkName = groups[1]!!.value

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/ValidateViolationsTaskTest.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.quality.tasks
 
 import net.twisterrob.gradle.common.ALL_VARIANTS_NAME
 import net.twisterrob.gradle.common.grouper.Grouper
+import net.twisterrob.gradle.common.listFilesInDirectory
 import net.twisterrob.gradle.quality.Violations
 import net.twisterrob.gradle.test.GradleRunnerRule
 import net.twisterrob.gradle.test.GradleRunnerRuleExtension
@@ -91,7 +92,7 @@ class ValidateViolationsTaskTest {
 	@Test fun `get per module violation counts`() {
 		val template = gradle.templateFile("checkstyle-multiple_violations/checkstyle-template.xml").readText()
 		val dir = gradle.templateFile("checkstyle-multiple_violations")
-		dir.listFiles().orEmpty().sorted().forEach { file: File ->
+		dir.listFilesInDirectory().sorted().forEach { file: File ->
 			println("Building module from ${file}")
 			VIOLATION_PATTERN.matchEntire(file.name)?.apply {
 				val checkName = groups[1]!!.value


### PR DESCRIPTION
Unannotated File.listFiles() was returning a nullable `File[]`, now if that happens a proper error will be thrown.