### PR TITLE
Fix #119: Enable Parallel builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,14 +33,6 @@ subprojects {
 	}
 }
 
-@Suppress("UnstableApiUsage")
-abstract class TestTaskLimiter : BuildService<BuildServiceParameters.None>
-
-@Suppress("UnstableApiUsage")
-gradle.sharedServices.registerIfAbsent("testTaskLimiter", TestTaskLimiter::class) {
-	maxParallelUsages.set(1)
-}
-
 allprojects {
 	replaceGradlePluginAutoDependenciesWithoutKotlin()
 
@@ -97,8 +89,6 @@ allprojects {
 		}
 
 		tasks.withType<Test> {
-			@Suppress("UnstableApiUsage")
-			usesService(gradle.sharedServices.registrations["testTaskLimiter"].service)
 			useJUnitPlatform()
 
 			if (System.getProperties().containsKey("idea.paths.selector")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,14 @@ subprojects {
 	}
 }
 
+@Suppress("UnstableApiUsage")
+abstract class TestTaskLimiter : BuildService<BuildServiceParameters.None>
+
+@Suppress("UnstableApiUsage")
+gradle.sharedServices.registerIfAbsent("testTaskLimiter", TestTaskLimiter::class) {
+	maxParallelUsages.set(1)
+}
+
 allprojects {
 	replaceGradlePluginAutoDependenciesWithoutKotlin()
 
@@ -89,6 +97,8 @@ allprojects {
 		}
 
 		tasks.withType<Test> {
+			@Suppress("UnstableApiUsage")
+			usesService(gradle.sharedServices.registrations["testTaskLimiter"].service)
 			useJUnitPlatform()
 
 			if (System.getProperties().containsKey("idea.paths.selector")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-# TODO enable this, but disable for tests, otherwise: parallel build: 50s+, normal build: ~40s
-#org.gradle.parallel=true
+# See TestTaskLimiter on how test tasks are limited in parallel execution.
+org.gradle.parallel=true
 org.gradle.warning.mode=all
 org.gradle.deprecation.trace=true
 # -Xmx256M locally, and even -Xmx512M on GitHub Actions is not enough for Dokka 1.4.32, so let's give it -Xmx768M

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-# See TestTaskLimiter on how test tasks are limited in parallel execution.
 org.gradle.parallel=true
 org.gradle.warning.mode=all
 org.gradle.deprecation.trace=true


### PR DESCRIPTION
Fixes #119

There was no need for test limiter service, because there was no speed degradation as before. Probably newer Gradle works better.