### PR TITLE
Unify lintOptions.check syntax

### DIFF
--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTaskTest.kt
@@ -231,7 +231,8 @@ class GlobalLintGlobalFinalizerTaskTest {
 				apply plugin: 'com.android.library'
 				android {
 					lintOptions {
-						check 'LongLogTag'
+						//noinspection GroovyAssignabilityCheck
+						check = ['LongLogTag']
 					}
 				}
 			""".trimIndent()


### PR DESCRIPTION
Fixes #124 by using an overload that doesn't warn.
https://issuetracker.google.com/issues/190540249

Didn't want to add a conditional as long as it's not necessary, when supporting 7.0 these tests will break, but that's farther down the line.