### PR TITLE
Unroll actions/download-artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -417,10 +417,139 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Download Artifacts
+      # Below many steps simulate the following missing feature from download-artifact:
+      # https://github.com/actions/download-artifact/issues/103
+      #- name: Download Artifacts
+      #  uses: actions/download-artifact@v2
+      #  with:
+      #    name: * Test Results XMLs
+      #    path: artifacts
+
+      - name: Download 'AGP 3.1.x on Gradle 4.4+ (3.1.4 on 4.9) Test Results XMLs'
         uses: actions/download-artifact@v2
         with:
-          path: artifacts
+          name: AGP 3.1.x on Gradle 4.4+ (3.1.4 on 4.9) Test Results XMLs
+          path: artifacts/AGP 3.1.x on Gradle 4.4+ (3.1.4 on 4.9) Test Results XMLs
+
+      - name: Download 'AGP 3.2.x on Gradle 4.6+ (3.2.1 on 4.9) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.2.x on Gradle 4.6+ (3.2.1 on 4.9) Test Results XMLs
+          path: artifacts/AGP 3.2.x on Gradle 4.6+ (3.2.1 on 4.9) Test Results XMLs
+
+      - name: Download 'AGP 3.3.x on Gradle 4.10.1+ (3.3.3 on 4.10.3) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.3.x on Gradle 4.10.1+ (3.3.3 on 4.10.3) Test Results XMLs
+          path: artifacts/AGP 3.3.x on Gradle 4.10.1+ (3.3.3 on 4.10.3) Test Results XMLs
+
+      - name: Download 'AGP 3.3.x on Gradle 5.x (3.3.3 on 5.4.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.3.x on Gradle 5.x (3.3.3 on 5.4.1) Test Results XMLs
+          path: artifacts/AGP 3.3.x on Gradle 5.x (3.3.3 on 5.4.1) Test Results XMLs
+
+      - name: Download 'AGP 3.4.x on Gradle 5.1.1+ (3.4.3 on 5.6.4) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.4.x on Gradle 5.1.1+ (3.4.3 on 5.6.4) Test Results XMLs
+          path: artifacts/AGP 3.4.x on Gradle 5.1.1+ (3.4.3 on 5.6.4) Test Results XMLs
+
+      - name: Download 'AGP 3.5.x on Gradle 5.4.1-5.6.4 (3.5.4 on 5.6.4) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.5.x on Gradle 5.4.1-5.6.4 (3.5.4 on 5.6.4) Test Results XMLs
+          path: artifacts/AGP 3.5.x on Gradle 5.4.1-5.6.4 (3.5.4 on 5.6.4) Test Results XMLs
+
+      - name: Download 'AGP 3.5.x on Gradle 6.x (3.5.4 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.5.x on Gradle 6.x (3.5.4 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 3.5.x on Gradle 6.x (3.5.4 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 3.6.x on Gradle 5.6.4+ (3.6.4 on 5.6.4) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.6.x on Gradle 5.6.4+ (3.6.4 on 5.6.4) Test Results XMLs
+          path: artifacts/AGP 3.6.x on Gradle 5.6.4+ (3.6.4 on 5.6.4) Test Results XMLs
+
+      - name: Download 'AGP 3.6.x on Gradle 6.x (3.6.4 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 3.6.x on Gradle 6.x (3.6.4 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 3.6.x on Gradle 6.x (3.6.4 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.0.x on Gradle 6.1.1+ (4.0.2 on 6.1.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.0.x on Gradle 6.1.1+ (4.0.2 on 6.1.1) Test Results XMLs
+          path: artifacts/AGP 4.0.x on Gradle 6.1.1+ (4.0.2 on 6.1.1) Test Results XMLs
+
+      - name: Download 'AGP 4.0.x on Gradle 6.1.1+ - plugin (4.0.2 on 6.1.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.0.x on Gradle 6.1.1+ - plugin (4.0.2 on 6.1.1) Test Results XMLs
+          path: artifacts/AGP 4.0.x on Gradle 6.1.1+ - plugin (4.0.2 on 6.1.1) Test Results XMLs
+
+      - name: Download 'AGP 4.0.x on Gradle 6.x (4.0.2 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.0.x on Gradle 6.x (4.0.2 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.0.x on Gradle 6.x (4.0.2 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.0.x on Gradle 6.x - plugin (4.0.2 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.0.x on Gradle 6.x - plugin (4.0.2 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.0.x on Gradle 6.x - plugin (4.0.2 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.1.x on Gradle 6.5+ (4.1.3 on 6.5.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.1.x on Gradle 6.5+ (4.1.3 on 6.5.1) Test Results XMLs
+          path: artifacts/AGP 4.1.x on Gradle 6.5+ (4.1.3 on 6.5.1) Test Results XMLs
+
+      - name: Download 'AGP 4.1.x on Gradle 6.5+ - plugin (4.1.3 on 6.5.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.1.x on Gradle 6.5+ - plugin (4.1.3 on 6.5.1) Test Results XMLs
+          path: artifacts/AGP 4.1.x on Gradle 6.5+ - plugin (4.1.3 on 6.5.1) Test Results XMLs
+
+      - name: Download 'AGP 4.1.x on Gradle 6.x (4.1.3 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.1.x on Gradle 6.x (4.1.3 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.1.x on Gradle 6.x (4.1.3 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.1.x on Gradle 6.x - plugin (4.1.3 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.1.x on Gradle 6.x - plugin (4.1.3 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.1.x on Gradle 6.x - plugin (4.1.3 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.2.x on Gradle 6.7.1+ (4.2.2 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.2.x on Gradle 6.7.1+ (4.2.2 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.2.x on Gradle 6.7.1+ (4.2.2 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.2.x on Gradle 6.7.1+ - plugin (4.2.2 on 6.7.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.2.x on Gradle 6.7.1+ - plugin (4.2.2 on 6.7.1) Test Results XMLs
+          path: artifacts/AGP 4.2.x on Gradle 6.7.1+ - plugin (4.2.2 on 6.7.1) Test Results XMLs
+
+      - name: Download 'AGP 4.2.x on Gradle 6.x (4.2.2 on 6.9.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.2.x on Gradle 6.x (4.2.2 on 6.9.1) Test Results XMLs
+          path: artifacts/AGP 4.2.x on Gradle 6.x (4.2.2 on 6.9.1) Test Results XMLs
+
+      - name: Download 'AGP 4.2.x on Gradle 6.x - plugin (4.2.2 on 6.9.1) Test Results XMLs'
+        uses: actions/download-artifact@v2
+        with:
+          name: AGP 4.2.x on Gradle 6.x - plugin (4.2.2 on 6.9.1) Test Results XMLs
+          path: artifacts/AGP 4.2.x on Gradle 6.x - plugin (4.2.2 on 6.9.1) Test Results XMLs
 
       #- name: Display structure of downloaded files
       #  run: ls -R


### PR DESCRIPTION
Recently "Publish Tests Results" timed out after 5 minutes in https://github.com/TWiStErRob/net.twisterrob.gradle/pull/148
I have a feeling it's because of https://github.com/actions/download-artifact/issues/103
Which became even more apparent after adding the 6 :plugin runs to the matrix.
It's ugly and unmaintainable af, but let's hope at least it'll be fast.