### PR TITLE
Fix #130: Render lint title as markdown

### DIFF
--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModel.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModel.kt
@@ -28,7 +28,7 @@ class DetailsViewModel(private val v: Violation) {
 						.replace("""&""", """&amp;""")
 
 					val details = LintMessageDetailsSplitter().split(v)
-					title = details.title.preprocessLintMarkdown()
+					title = details.title.preprocessLintMarkdown().escapeMarkdownForJSTemplate()
 					message = details.message.preprocessLintMarkdown().escapeMarkdownForJSTemplate()
 					description = details.description.preprocessLintMarkdown().escapeMarkdownForJSTemplate()
 				}

--- a/quality/src/main/resources/violations.xsl
+++ b/quality/src/main/resources/violations.xsl
@@ -146,9 +146,12 @@
 			<a name="{details/@category}-{source/@reporter}-{details/@rule}" />
 		</xsl:if>
 		<div class="violation" xml:space="preserve">
-			<!-- @formatter:off -->
-			<b><code class="rule copyable" title="To suppress:&#xA;&#xA;{details/@suppress}&#xA;&#xA;Click to copy!" onClick="copyToClipboard(`{details/@suppress}`)"><xsl:value-of select="details/@rule" /></code>: <xsl:value-of select="details/title" /></b><br />
-			<!-- @formatter:on -->
+			<span class="title">
+				<!-- @formatter:off -->
+				<b><code class="rule copyable" title="To suppress:&#xA;&#xA;{details/@suppress}&#xA;&#xA;Click to copy!" onClick="copyToClipboard(`{details/@suppress}`)"><xsl:value-of select="details/@rule" /></code>: <script>render.markdown(`<xsl:value-of select="details/title" />`)</script></b>
+				<!-- @formatter:on -->
+			</span>
+			<br />
 			<details class="location">
 				<xsl:if test="details/context/@type != 'archive' or string-length(details/context) - string-length(translate(details/context, '&#x0A;', '')) &lt; 25">
 					<xsl:attribute name="open">open</xsl:attribute>
@@ -344,6 +347,7 @@
 		max-width: 900px;
 	}
 
+	.violation .title p,
 	.violation > details.description > summary > p {
 		display: inline;
 	}

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/development/DevelopmentTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/development/DevelopmentTest.kt
@@ -64,12 +64,12 @@ class DevelopmentTest {
 	//	@Test
 	fun `manual test for a specific lint failure`() {
 		gradle.basedOn("android-root_app")
-		val stringsXml = resources.customLint.typographyFractions.violation
-		gradle.file(stringsXml, "src", "main", "res", "values", "strings.xml")
+		val violationContents = resources.customLint.secureRandom.violation
+		gradle.file(violationContents, "src", "main", "java", "LintFailure.java")
 		@Language("gradle")
 		val script = """
 			apply plugin: 'org.gradle.reporting-base'
-			android.lintOptions.checkOnly("TypographyFractions")
+			android.lintOptions.checkOnly("SecureRandom")
 			task('htmlReport', type: ${HtmlReportTask::class.java.name})
 		""".trimIndent()
 

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModelTest_ANDROIDLINT.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/report/html/model/DetailsViewModelTest_ANDROIDLINT.kt
@@ -49,9 +49,9 @@ class DetailsViewModelTest_ANDROIDLINT {
 		val model = DetailsViewModel(fixture.build<Violation>().apply {
 			val input = """&, &amp;, `&amp;`, text: &#188;, code: `&#188;`"""
 			val lintMessage = """
-				Title: $input
-				Message: $input
-				Description: $input
+				Title: ${input}
+				Message: ${input}
+				Description: ${input}
 			""".trimIndent()
 			setField("message", lintMessage)
 		})
@@ -60,18 +60,10 @@ class DetailsViewModelTest_ANDROIDLINT {
 
 		// The real expectation would be different, but that would require full syntactic parsing of lint's markdown.
 		// See https://github.com/TWiStErRob/net.twisterrob.gradle/issues/65#issuecomment-860275509.
-		assertEquals(
-			"""Title: &amp;, &amp;amp;, `&amp;amp;`, text: &amp;#188;, code: `&amp;#188;`""",
-			result.title
-		)
-		assertEquals(
-			"""Message: &amp;, &amp;amp;, \`&amp;amp;\`, text: &amp;#188;, code: \`&amp;#188;\`""",
-			result.message
-		)
-		assertEquals(
-			"""Description: &amp;, &amp;amp;, \`&amp;amp;\`, text: &amp;#188;, code: \`&amp;#188;\`""",
-			result.description
-		)
+		val expected = """&amp;, &amp;amp;, \`&amp;amp;\`, text: &amp;#188;, code: \`&amp;#188;\`"""
+		assertEquals("Title: ${expected}", result.title)
+		assertEquals("Message: ${expected}", result.message)
+		assertEquals("Description: ${expected}", result.description)
 	}
 
 	companion object {

--- a/quality/src/testFixtures/kotlin/DevelopmentTestResources.kt
+++ b/quality/src/testFixtures/kotlin/DevelopmentTestResources.kt
@@ -24,6 +24,16 @@ class DevelopmentTestResources {
 			val xmlReport: String
 				get() = read("custom-lint/TypographyFractions/lint-results.xml")
 		}
+
+		val secureRandom get() = object : SecureRandom {}
+
+		interface SecureRandom {
+			val violation: String
+				get() = read("custom-lint/SecureRandom/LintFailure.java")
+
+			val xmlReport: String
+				get() = read("custom-lint/SecureRandom/lint-results.xml")
+		}
 	}
 
 	companion object {

--- a/quality/src/testFixtures/resources/net/twisterrob/gradle/quality/development/custom-lint/SecureRandom/LintFailure.java
+++ b/quality/src/testFixtures/resources/net/twisterrob/gradle/quality/development/custom-lint/SecureRandom/LintFailure.java
@@ -1,0 +1,7 @@
+import java.security.SecureRandom;
+
+class LintFailure {
+	void f() {
+		new SecureRandom().setSeed(0);
+	}
+}

--- a/quality/src/testFixtures/resources/net/twisterrob/gradle/quality/development/custom-lint/SecureRandom/lint-results.xml
+++ b/quality/src/testFixtures/resources/net/twisterrob/gradle/quality/development/custom-lint/SecureRandom/lint-results.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="5" by="lint 4.2.2">
+
+    <issue
+        id="SecureRandom"
+        severity="Warning"
+        message="Do not call `setSeed()` on a `SecureRandom` with a fixed seed: it is not secure. Use `getSeed()`."
+        category="Security"
+        priority="9"
+        summary="Using a fixed seed with `SecureRandom`"
+        explanation="Specifying a fixed seed will cause the instance to return a predictable sequence of numbers. This may be useful for testing but it is not appropriate for secure use."
+        url="https://developer.android.com/reference/java/security/SecureRandom.html"
+        urls="https://developer.android.com/reference/java/security/SecureRandom.html"
+        errorLine1="  new SecureRandom().setSeed(0);"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="C:\Users\TWiStEr\AppData\Local\Temp\junit9141543391964979463\src\main\java\LintFailure.java"
+            line="5"
+            column="3"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
Fixes #130

before
![image](https://user-images.githubusercontent.com/2906988/137644555-7734f519-5e48-4805-a4ba-51164a1244a0.png)

after
![image](https://user-images.githubusercontent.com/2906988/137644548-ef83de6e-c52a-4227-bb2d-6449f68a1457.png)
