### PR TITLE
autoVersion improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
       # Value will be written in a later step using `>> $GITHUB_ENV`.
       GRADLE_VERSION: 0.0.0
     # Average observed execution time is 6-7 minutes, double it for timeout constraint.
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - run: echo "Running in response to a ${{ github.event_name }} event, building ${{ github.event.compare }} changes."

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/BaseAndroidIntgTest.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/BaseAndroidIntgTest.kt
@@ -12,13 +12,6 @@ abstract class BaseAndroidIntgTest : BaseIntgTest() {
 	@BeforeEach fun setUp(testInfo: TestInfo) {
 		gradle.basedOn(GradleBuildTestResources.android)
 
-		@Language("properties")
-		val versionProperties = """
-			# Since AGP 3.3 versionCode must be > 0
-			build=1
-		""".trimIndent()
-		gradle.file(versionProperties, "version.properties")
-
 		if (testInfo.testMethod.get().name.endsWith(" (release)")) {
 			createFileToMakeSureProguardPasses()
 		}

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
@@ -25,7 +25,13 @@ fun File.apk(
 	variant: String,
 	fileName: String = run {
 		val variantSuffix = if (variant != "release") ".${variant}" else ""
-		"${packageName}${variantSuffix}@-1-vnull+${variant}.apk"
+		val versionName = when {
+			AGPVersions.UNDER_TEST compatible AGPVersions.v40x ->
+				if ("debug" in variant) "d" else "null"
+			else ->
+				"null"
+		}
+		"${packageName}${variantSuffix}@-1-v${versionName}+${variant}.apk"
 	}
 ): File =
 	this.resolve("build/outputs/apk").resolve(variant).resolve(fileName)
@@ -69,7 +75,12 @@ fun assertDefaultDebugBadging(
 	apk: File,
 	applicationId: String = "${packageName}.debug",
 	versionCode: String = "",
-	versionName: String = "",
+	versionName: String = when {
+		AGPVersions.UNDER_TEST compatible AGPVersions.v40x ->
+			"d"
+		else ->
+			"null"
+	},
 	compileSdkVersion: Int = VERSION_SDK_COMPILE,
 	compileSdkVersionName: String = VERSION_SDK_COMPILE_NAME,
 	minSdkVersion: Int = VERSION_SDK_MINIMUM,

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
@@ -25,8 +25,7 @@ fun File.apk(
 	variant: String,
 	fileName: String = run {
 		val variantSuffix = if (variant != "release") ".${variant}" else ""
-		val variantVersionSuffix = if ("debug" in variant) "d" else ""
-		"${packageName}${variantSuffix}@1-v0.0.0#1${variantVersionSuffix}+${variant}.apk"
+		"${packageName}${variantSuffix}@-1-vnull+${variant}.apk"
 	}
 ): File =
 	this.resolve("build/outputs/apk").resolve(variant).resolve(fileName)
@@ -69,8 +68,8 @@ private fun resolveFromFolders(command: String, vararg dirs: File): File {
 fun assertDefaultDebugBadging(
 	apk: File,
 	applicationId: String = "${packageName}.debug",
-	versionCode: String = "1",
-	versionName: String = "0.0.0#1d",
+	versionCode: String = "",
+	versionName: String = "",
 	compileSdkVersion: Int = VERSION_SDK_COMPILE,
 	compileSdkVersionName: String = VERSION_SDK_COMPILE_NAME,
 	minSdkVersion: Int = VERSION_SDK_MINIMUM,
@@ -91,8 +90,8 @@ fun assertDefaultDebugBadging(
 fun assertDefaultReleaseBadging(
 	apk: File,
 	applicationId: String = packageName,
-	versionCode: String = "1",
-	versionName: String = "0.0.0#1",
+	versionCode: String = "",
+	versionName: String = "",
 	compileSdkVersion: Int = VERSION_SDK_COMPILE,
 	compileSdkVersionName: String = VERSION_SDK_COMPILE_NAME,
 	minSdkVersion: Int = VERSION_SDK_MINIMUM,
@@ -113,8 +112,8 @@ fun assertDefaultReleaseBadging(
 fun assertDefaultBadging(
 	apk: File,
 	applicationId: String = "${packageName}.debug",
-	versionCode: String = "1",
-	versionName: String = "0.0.0#1d",
+	versionCode: String = "",
+	versionName: String = "",
 	compileSdkVersion: Int = VERSION_SDK_COMPILE,
 	compileSdkVersionName: String = VERSION_SDK_COMPILE_NAME,
 	minSdkVersion: Int = VERSION_SDK_MINIMUM,

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
@@ -79,7 +79,7 @@ fun assertDefaultDebugBadging(
 		AGPVersions.UNDER_TEST compatible AGPVersions.v40x ->
 			"d"
 		else ->
-			"null"
+			""
 	},
 	compileSdkVersion: Int = VERSION_SDK_COMPILE,
 	compileSdkVersionName: String = VERSION_SDK_COMPILE_NAME,

--- a/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/AndroidBuildPluginIntgTest.kt
+++ b/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/AndroidBuildPluginIntgTest.kt
@@ -171,7 +171,6 @@ class AndroidBuildPluginIntgTest : BaseAndroidIntgTest() {
 			}
 		""".trimIndent()
 		gradle.file(appGradle, "app", "build.gradle")
-		gradle.move("version.properties", "app/version.properties")
 		gradle.move("src/main/AndroidManifest.xml", "app/src/main/AndroidManifest.xml")
 
 		@Language("gradle")

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
@@ -81,7 +81,10 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 			afterEvaluate {
 				tasks.named("releaseRelease", Zip) { destinationDirectory.set(file('releases/release')) }
 			}
@@ -126,7 +129,10 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 			afterEvaluate {
 				tasks.named("releaseDebug", Zip) { destinationDirectory.set(file('releases/debug')) }
 			}
@@ -167,7 +173,10 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 			afterEvaluate {
 				tasks.named("releaseRelease", Zip) { destinationDirectory.set(file('releases/release')) }
 				tasks.named("releaseDebug", Zip) { destinationDirectory.set(file('releases/debug')) }
@@ -186,7 +195,14 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 	}
 
 	private inline fun assertArchive(archive: File, crossinline assertions: (File) -> Unit) {
-		assertThat(archive, anExistingFile())
+		val fileNamesMessage =
+			"Wanted: ${archive.absolutePath}${System.lineSeparator()}list: ${
+				archive.parentFile.listFiles().orEmpty().joinToString(
+					prefix = System.lineSeparator(),
+					separator = System.lineSeparator()
+				)
+			}"
+		assertThat(fileNamesMessage, archive, anExistingFile())
 		try {
 			assertions(archive)
 		} catch (ex: Throwable) {

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
@@ -81,10 +81,7 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 			afterEvaluate {
 				tasks.named("releaseRelease", Zip) { destinationDirectory.set(file('releases/release')) }
 			}
@@ -129,10 +126,7 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 			afterEvaluate {
 				tasks.named("releaseDebug", Zip) { destinationDirectory.set(file('releases/debug')) }
 			}
@@ -173,10 +167,7 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 			afterEvaluate {
 				tasks.named("releaseRelease", Zip) { destinationDirectory.set(file('releases/release')) }
 				tasks.named("releaseDebug", Zip) { destinationDirectory.set(file('releases/debug')) }

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
@@ -6,17 +6,21 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.internal.api.TestedVariant
+import com.android.build.gradle.internal.dsl.DefaultConfig
 import net.twisterrob.gradle.base.BasePlugin
 import net.twisterrob.gradle.compat.archivesBaseNameCompat
 import net.twisterrob.gradle.kotlin.dsl.extensions
 import net.twisterrob.gradle.kotlin.dsl.withId
 import net.twisterrob.gradle.vcs.VCSExtension
 import net.twisterrob.gradle.vcs.VCSPluginExtension
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.PluginInstantiationException
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.withType
 import java.io.File
 import java.io.FileInputStream
@@ -24,6 +28,20 @@ import java.io.FileNotFoundException
 import java.util.Locale
 import java.util.Properties
 
+/**
+ * To use in Kotlin DSL use
+ * ```kotlin
+ * android.defaultConfig.version.…
+ * ```
+ * or
+ * ```kotlin
+ * android.defaultConfig.version {
+ *     …
+ * }
+ * ```
+ * Note: in Groovy DSL this is automatic.
+ * @see version
+ */
 @Suppress("MemberVisibilityCanBePrivate")
 open class AndroidVersionExtension {
 
@@ -170,4 +188,11 @@ class AndroidVersionPlugin : BasePlugin() {
 			} catch (ignore: FileNotFoundException) {
 			}
 		}
+}
+
+val DefaultConfig.version: AndroidVersionExtension
+	get() = (this as ExtensionAware).extensions.getByName<AndroidVersionExtension>("version")
+
+fun DefaultConfig.version(configuration: Action<AndroidVersionExtension>) {
+	configuration.execute(version)
 }

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
@@ -51,20 +51,53 @@ open class AndroidVersionExtension {
 		internal const val DEFAULT_FILE_NAME: String = "version.properties"
 	}
 
+	private var autoVersionSet: Boolean = false
+
 	/**
 	 * Default versionCode pattern is MMMNNPPBBB (what fits into 2147483648).
 	 * Adjust [minorMagnitude], [patchMagnitude] and [buildMagnitude] to change this.
 	 *
 	 * autoVersion will default to `true` when `version.properties` file exists.
+	 * autoVersion will default to `true` when [major], [minor], [patch] or [build] properties are set.
 	 */
 	var autoVersion: Boolean = false
+		set(value) {
+			field = value
+			autoVersionSet = true
+		}
+
 	var versionNameFormat: String = "%1\$d.%2\$d.%3\$d#%4\$d"
+
 	var major: Int = 0 // M 0..213
+		set(value) {
+			field = value
+			autoVersion()
+		}
+
 	var minor: Int = 0 // N 0..99
+		set(value) {
+			field = value
+			autoVersion()
+		}
 	var minorMagnitude: Int = 100
+
 	var patch: Int = 0 // P 0..99
+		set(value) {
+			field = value
+			autoVersion()
+		}
 	var patchMagnitude: Int = 100
+
 	var build: Int = 0 // B 0..999
+		set(value) {
+			field = value
+			autoVersion()
+		}
+
+	private fun autoVersion() {
+		if (!autoVersionSet) autoVersion = true
+	}
+
 	var buildMagnitude: Int = 1000
 
 	/** VCS versionCode pattern is MMMNPBBBBB (what fits into 2147483648) */

--- a/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
+++ b/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
@@ -170,10 +170,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebug").build()
@@ -190,10 +187,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -210,10 +204,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebugAndroidTest").build()
@@ -235,11 +226,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				renameAPK = false
-				major = 1; minor = 2; patch = 3; build = 4
-		}
+			android.defaultConfig.version { renameAPK = false; major = 1; minor = 2; patch = 3; build = 4 }
 		""".trimIndent()
 		val projectName = "gradle-test-project"
 		gradle.settingsFile.appendText("rootProject.name = '$projectName'")
@@ -258,11 +245,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				renameAPK = false
-				major = 1; minor = 2; patch = 3; build = 4
-			}
+			android.defaultConfig.version { renameAPK = false; major = 1; minor = 2; patch = 3; build = 4 }
 		""".trimIndent()
 		val projectName = "gradle-test-project"
 		gradle.settingsFile.appendText("rootProject.name = '$projectName'")
@@ -344,10 +327,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3/*; build = 4*/
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3/*; build = 4*/ }
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -371,10 +351,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version {
-				autoVersion = true
-				major = 1; minor = 2; patch = 3/*; build = 4*/
-			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3/*; build = 4*/ }
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()

--- a/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
+++ b/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
@@ -212,12 +212,12 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 
 		result.assertSuccess(":assembleDebug")
 		assertDefaultDebugBadging(
-			apk = gradle.root.apk("debug", "${packageName}.debug@-1-vnull+debug.apk")
+			apk = gradle.root.apk("debug")
 		)
 
 		result.assertSuccess(":assembleRelease")
 		assertDefaultReleaseBadging(
-			apk = gradle.root.apk("release", "${packageName}@-1-vnull+release.apk")
+			apk = gradle.root.apk("release")
 		)
 	}
 

--- a/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
+++ b/plugin/versioning/src/test/kotlin/net/twisterrob/gradle/android/AndroidVersionPluginIntgTest.kt
@@ -49,7 +49,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionCode = 1234
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebug").build()
@@ -77,7 +76,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionCode = 1234
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -85,8 +83,7 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		result.assertSuccess(":assembleRelease")
 		assertDefaultReleaseBadging(
 			apk = gradle.root.apk("release", "${packageName}@1234-vnull+release.apk"),
-			versionCode = "1234",
-			versionName = ""
+			versionCode = "1234"
 		)
 	}
 
@@ -95,7 +92,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionCode = 1234
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebugAndroidTest").build()
@@ -125,7 +121,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionName = "_custom_"
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebug").build()
@@ -133,7 +128,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		result.assertSuccess(":assembleDebug")
 		assertDefaultDebugBadging(
 			apk = gradle.root.apk("debug", "${packageName}.debug@-1-v_custom_d+debug.apk"),
-			versionCode = "",
 			versionName = "_custom_d"
 		)
 	}
@@ -143,7 +137,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionName = "_custom_"
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -151,7 +144,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		result.assertSuccess(":assembleRelease")
 		assertDefaultReleaseBadging(
 			apk = gradle.root.apk("release", "${packageName}@-1-v_custom_+release.apk"),
-			versionCode = "",
 			versionName = "_custom_"
 		)
 	}
@@ -161,7 +153,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
 			android.defaultConfig.versionName = "_custom_"
-			android.defaultConfig.version.autoVersion = false
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebugAndroidTest").build()
@@ -170,7 +161,6 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		assertDefaultBadging(
 			applicationId = "${packageName}.debug.test",
 			apk = gradle.root.apk("androidTest/debug", "${packageName}.debug.test@-1-v_custom_d+debug-androidTest.apk"),
-			versionCode = "",
 			versionName = "_custom_d",
 			isAndroidTestApk = true
 		)
@@ -180,7 +170,10 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebug").build()
@@ -197,7 +190,10 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -214,7 +210,10 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleDebugAndroidTest").build()
@@ -236,7 +235,11 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { renameAPK = false; major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				renameAPK = false
+				major = 1; minor = 2; patch = 3; build = 4
+		}
 		""".trimIndent()
 		val projectName = "gradle-test-project"
 		gradle.settingsFile.appendText("rootProject.name = '$projectName'")
@@ -255,7 +258,11 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { renameAPK = false; major = 1; minor = 2; patch = 3; build = 4 }
+			android.defaultConfig.version {
+				autoVersion = true
+				renameAPK = false
+				major = 1; minor = 2; patch = 3; build = 4
+			}
 		""".trimIndent()
 		val projectName = "gradle-test-project"
 		gradle.settingsFile.appendText("rootProject.name = '$projectName'")
@@ -267,6 +274,60 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 			apk = gradle.root.apk("release", "${projectName}-release-unsigned.apk"),
 			versionCode = "10203004",
 			versionName = "1.2.3#4"
+		)
+	}
+
+	@Test fun `autoVersion turns on when version properties file exists and overrides defaultConfig`() {
+		@Language("properties")
+		val versionProperties = """
+			# Since AGP 3.3 versionCode must be > 0
+			major=1
+			minor=2
+			patch=3
+			build=4
+		""".trimIndent()
+		gradle.file(versionProperties, "version.properties")
+
+		@Language("gradle")
+		val script = """
+			apply plugin: 'net.twisterrob.android-app'
+			android.defaultConfig.versionCode = 6789
+			android.defaultConfig.versionName = "_custom_"
+		""".trimIndent()
+
+		val result = gradle.run(script, "assembleRelease").build()
+
+		result.assertSuccess(":assembleRelease")
+		assertDefaultReleaseBadging(
+			apk = gradle.root.apk("release", "${packageName}@10203004-v1.2.3#4+release.apk"),
+			versionCode = "10203004",
+			versionName = "1.2.3#4"
+		)
+	}
+
+	@Test fun `autoVersion can be turned off even when the file exists`() {
+		@Language("properties")
+		val versionProperties = """
+			major=1
+			minor=2
+			patch=3
+			build=4
+		""".trimIndent()
+		gradle.file(versionProperties, "version.properties")
+
+		@Language("gradle")
+		val script = """
+			apply plugin: 'net.twisterrob.android-app'
+			android.defaultConfig.version.autoVersion = false
+			android.defaultConfig.versionName = "_custom_"
+		""".trimIndent()
+
+		val result = gradle.run(script, "assembleRelease").build()
+
+		result.assertSuccess(":assembleRelease")
+		assertDefaultReleaseBadging(
+			apk = gradle.root.apk("release", "${packageName}@-1-v_custom_+release.apk"),
+			versionName = "_custom_"
 		)
 	}
 
@@ -283,7 +344,10 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3/*; build = 4*/ }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3/*; build = 4*/
+			}
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()
@@ -307,7 +371,10 @@ class AndroidVersionPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
-			android.defaultConfig.version { major = 1; minor = 2; patch = 3/*; build = 4*/ }
+			android.defaultConfig.version {
+				autoVersion = true
+				major = 1; minor = 2; patch = 3/*; build = 4*/
+			}
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()


### PR DESCRIPTION
This improvement came about because I wanted to add `net.twisterrob.android-app` into `examples/local`, but had to create a valid `version.properties` to make it work, and additionally I needed to write some crazy Kotlin DSL for the extension to turn off auto-versioning.