### PR TITLE
Fix #175: R8 warns about -dump, because it's not supported; don't dump.

### DIFF
--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -124,6 +124,8 @@ class AndroidMinificationPlugin : BasePlugin() {
 				outputFile.createNewFile()
 				if (isProguard || AGPVersions.CLASSPATH < AGPVersions.v41x) {
 					outputFile.appendText("-printconfiguration ${mappingFolder.get().resolve("configuration.txt")}\n")
+				}
+				if (isProguard) {
 					outputFile.appendText("-dump ${mappingFolder.get().resolve("dump.txt")}\n")
 				}
 			}

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -177,13 +177,13 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 
 			Minification.R8 -> {
 				// Not supported on R8 at AGP 4.2.
-				result.assertNoOutputLine(""".*WARNING:.* R8: Ignoring option: -dump.*""".toRegex())
+				result.assertNoOutputLine(""".*R8: Ignoring option: -dump.*""".toRegex())
 				assertThat(gradle.root.resolve("build/outputs/mapping/release/dump.txt"), not(anExistingFile()))
 			}
 
 			Minification.R8Full -> {
 				// Not supported on R8 at AGP 4.2.
-				result.assertNoOutputLine(""".*WARNING:.* R8: Ignoring option: -dump.*""".toRegex())
+				result.assertNoOutputLine(""".*R8: Ignoring option: -dump.*""".toRegex())
 				assertThat(gradle.root.resolve("build/outputs/mapping/release/dump.txt"), not(anExistingFile()))
 			}
 		}

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -176,13 +176,13 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 			}
 
 			Minification.R8 -> {
-				// Not supported on R8 at AGP 4.2.
+				// Not supported on R8 at AGP 4.x.
 				result.assertNoOutputLine(""".*R8: Ignoring option: -dump.*""".toRegex())
 				assertThat(gradle.root.resolve("build/outputs/mapping/release/dump.txt"), not(anExistingFile()))
 			}
 
 			Minification.R8Full -> {
-				// Not supported on R8 at AGP 4.2.
+				// Not supported on R8 at AGP 4.x.
 				result.assertNoOutputLine(""".*R8: Ignoring option: -dump.*""".toRegex())
 				assertThat(gradle.root.resolve("build/outputs/mapping/release/dump.txt"), not(anExistingFile()))
 			}


### PR DESCRIPTION
Fixes #175