### PR TITLE
Fix CI warning with publish v2 action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1000,4 +1000,4 @@ jobs:
           comment_mode: off
           report_individual_runs: true
           test_changes_limit: 0
-          files: artifacts/* Test Results XMLs/**/*.xml
+          junit_files: artifacts/* Test Results XMLs/**/*.xml


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2906988/194838854-d7bcd7cd-8f8d-4043-a8c8-38acabdfdd24.png)

After:
![image](https://user-images.githubusercontent.com/2906988/194852223-bd70bbb2-6d95-4a66-a4f4-68d4b2465fdd.png)
