### PR TITLE
Ubuntu 22 vs Java 11 signing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: 1 🔨 Build
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     # A run took 5.5 minutes, give it a bit of a buffer (there's networking involved, download and upload), and constrain.
     timeout-minutes: 20
     steps:
@@ -149,7 +149,7 @@ jobs:
 
   check:
     name: 2 🛠️ ${{ matrix.name }}
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     env:
       JOB_NAME: ${{ matrix.name }} (${{ matrix.agp }} on ${{ matrix.gradle }})
       # Capture which Gradle version is running the build to use in some steps.
@@ -690,7 +690,7 @@ jobs:
   # Separate job for parsing the XML output, since the matrix runs on multiple machines.
   publish-test-results:
     name: 3 📢 Publish Tests Results
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: check
     # The dependency job might be skipped, we don't need to run this job then.
     if: success() || failure()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: 1 🔨 Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     # A run took 5.5 minutes, give it a bit of a buffer (there's networking involved, download and upload), and constrain.
     timeout-minutes: 20
     steps:
@@ -149,7 +149,7 @@ jobs:
 
   check:
     name: 2 🛠️ ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     env:
       JOB_NAME: ${{ matrix.name }} (${{ matrix.agp }} on ${{ matrix.gradle }})
       # Capture which Gradle version is running the build to use in some steps.
@@ -690,7 +690,7 @@ jobs:
   # Separate job for parsing the XML output, since the matrix runs on multiple machines.
   publish-test-results:
     name: 3 📢 Publish Tests Results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     needs: check
     # The dependency job might be skipped, we don't need to run this job then.
     if: success() || failure()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,9 +17,14 @@ jobs:
   # Lifted out to do at once, because action is not stable enough for parallel workflows ^.
   validate:
     name: 0 🦺 Validation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
     steps:
-    - name: Validate Gradle Wrapper JARs.
-      uses: gradle/wrapper-validation-action@v1
+      - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle Wrapper JARs.
+        uses: gradle/wrapper-validation-action@v1
 
   build:
     name: 1 🔨 Build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TODEL https://github.com/gradle/wrapper-validation-action/issues/69
+  # Lifted out to do at once, because action is not stable enough for parallel workflows ^.
+  validate:
+    name: 0 🦺 Validation
+    steps:
+    - name: Validate Gradle Wrapper JARs.
+      uses: gradle/wrapper-validation-action@v1
+
   build:
     name: 1 🔨 Build
     runs-on: ubuntu-22.04
     # A run took 5.5 minutes, give it a bit of a buffer (there's networking involved, download and upload), and constrain.
     timeout-minutes: 20
+    needs: validate
     steps:
       - name: Set up JDK 11.
         uses: actions/setup-java@v3
@@ -157,7 +166,7 @@ jobs:
       GRADLE_VERSION: 0.0.0
     # Average observed execution time is 6-7 minutes, double it for timeout constraint.
     timeout-minutes: 30
-
+    needs: validate
     steps:
       - run: echo "Running in response to a ${{ github.event_name }} event, building ${{ github.event.compare }} changes."
 
@@ -215,8 +224,12 @@ jobs:
       - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
         uses: actions/checkout@v3
 
-      - name: Validate Gradle Wrapper JARs.
-        uses: gradle/wrapper-validation-action@v1
+      # TODEL https://github.com/gradle/wrapper-validation-action/issues/69
+      # Commented out, because action is not stable enough for parallel workflows ^.
+      # jobs.build would validate it anyway, although with that, the matrix will still execute the bad code.
+      # To be sure, lifted as "needs" prerequisite at least until there's some response on the issue.
+      #- name: Validate Gradle Wrapper JARs.
+      #  uses: gradle/wrapper-validation-action@v1
 
       # To prevent "Welcome to Gradle <version>! Here are the highlights of this release:" in build log, use:
       #- run: touch ~/.gradle/notifications/5.6.4/release-features.rendered

--- a/plugin/signing/src/test/kotlin/net/twisterrob/gradle/android/AndroidSigningPluginIntgTest.kt
+++ b/plugin/signing/src/test/kotlin/net/twisterrob/gradle/android/AndroidSigningPluginIntgTest.kt
@@ -79,6 +79,12 @@ class AndroidSigningPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.android-app'
+			// Increase minimum version to avoid ignoring the signature:
+			// > jarsigner WARNING: The jar will be treated as unsigned,
+			// > because it is signed with a weak algorithm that is now disabled by the security property
+			// This happens on GitHub Actions ubuntu-2204 runners because java.security file contains:
+			// jdk.jar.disabledAlgorithms=SHA1 denyAfter 2019-01-01
+			android.defaultConfig.minSdkVersion = 21
 		""".trimIndent()
 
 		val result = gradle.run(script, "assembleRelease").build()

--- a/plugin/signing/src/test/kotlin/net/twisterrob/gradle/android/AndroidSigningPluginIntgTest.kt
+++ b/plugin/signing/src/test/kotlin/net/twisterrob/gradle/android/AndroidSigningPluginIntgTest.kt
@@ -129,7 +129,16 @@ class AndroidSigningPluginIntgTest : BaseAndroidIntgTest() {
 		listOf(
 			resolveFromJDK("jarsigner").absolutePath,
 			"-verify",
-			"-verbose",
+
+			// Turn this on to see more output in case of failure.
+			"-verbose", // Print details of files.
+
+			// Can't turn this on, because of warnings that cannot be fixed reasonably.
+			//"-strict", // Make warnings on stderr into errors, with non-0 exit code.
+
+			// Don't include this in repo, because it hangs the test on local execution.
+			//"-J-Djava.security.debug=jar", // Print details of JAR verification.
+
 			apk
 		).runCommand()
 }


### PR DESCRIPTION
Since `ubuntu-latest` was aliased to 22 [recently](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/). Some configuration changed and CI started failing:
```
java.lang.AssertionError: 
Expected: (a string containing "jar verified." and a string containing "CN=JUnit Test, O=net.twisterrob, L=Gradle")
     but: a string containing "jar verified." was "
 m  ?     56 Thu Jan 01 01:01:02 UTC 1981 META-INF/com/android/build/gradle/app-metadata.properties
 m  ?    784 Thu Jan 01 01:01:02 UTC 1981 classes.dex
 m  ?   1008 Thu Jan 01 01:01:02 UTC 1981 AndroidManifest.xml
 m  ?    780 Thu Jan 01 01:01:02 UTC 1981 resources.arsc
         450 Thu Jan 01 01:01:02 UTC 1981 META-INF/CERT.SF
        1227 Thu Jan 01 01:01:02 UTC 1981 META-INF/CERT.RSA
         395 Thu Jan 01 01:01:02 UTC 1981 META-INF/MANIFEST.MF

  s = signature was verified 
  m = entry is listed in manifest
  k = at least one certificate was found in keystore
  ? = unsigned entry

- Signed by "CN=JUnit Test, O=net.twisterrob, L=Gradle"
    Digest algorithm: SHA1 (disabled)
    Signature algorithm: SHA1withRSA (disabled), 2048-bit key

WARNING: The jar will be treated as unsigned, because it is signed with a weak algorithm that is now disabled by the security property:

  jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, DSA keySize < 1024, SHA1 denyAfter 2019-01-01, include jdk.disabled.namedCurves
"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at net.twisterrob.gradle.android.AndroidSigningPluginIntgTest.applies signing config from properties (release)(AndroidSigningPluginIntgTest.kt:106)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```