### PR TITLE
Fix #214: Add dependency on generate...LintModel for proguard generation tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,11 @@ net.twisterrob.test.android.compileSdkVersion=android-30
 
 # Default test substitutions (overridden by .github/workflows/ci.yml with -P)
 # AGP: 3.3.3, 3.4.3, 3.5.4, 3.6.4, 4.0.2, 4.1.3, 4.2.2, 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.1
-net.twisterrob.test.android.pluginVersion=7.1.2
+net.twisterrob.test.android.pluginVersion=7.4.1
 # Kotlin: AGP 3.3.3-7.2.2 -> Kotlin 1.4.32; AGP 7.3.0- -> Kotlin 1.6.21
-net.twisterrob.test.kotlin.pluginVersion=1.6.10
+net.twisterrob.test.kotlin.pluginVersion=1.6.21
 # Gradle: 5.4.1, 5.6.4; 6.1.1, 6.5.1, 6.7.1, 6.9.2; 7.0.2, 7.2, 7.3.3, 7.4.2, 7.5.1, 7.6, 8.0
-net.twisterrob.gradle.runner.gradleVersion=7.4
+net.twisterrob.gradle.runner.gradleVersion=8.0-rc-5
 # AGP 3.3.3-4.2.2 -> Java 8; AGP 7.0.0-7.4.0 -> Java 11; AGP 8.0.0- -> Java 17
 net.twisterrob.test.gradle.javaHomeEnv=JAVA11_HOME
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,11 @@ net.twisterrob.test.android.compileSdkVersion=android-30
 
 # Default test substitutions (overridden by .github/workflows/ci.yml with -P)
 # AGP: 3.3.3, 3.4.3, 3.5.4, 3.6.4, 4.0.2, 4.1.3, 4.2.2, 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.1
-net.twisterrob.test.android.pluginVersion=7.4.1
+net.twisterrob.test.android.pluginVersion=7.1.2
 # Kotlin: AGP 3.3.3-7.2.2 -> Kotlin 1.4.32; AGP 7.3.0- -> Kotlin 1.6.21
-net.twisterrob.test.kotlin.pluginVersion=1.6.21
+net.twisterrob.test.kotlin.pluginVersion=1.6.10
 # Gradle: 5.4.1, 5.6.4; 6.1.1, 6.5.1, 6.7.1, 6.9.2; 7.0.2, 7.2, 7.3.3, 7.4.2, 7.5.1, 7.6, 8.0
-net.twisterrob.gradle.runner.gradleVersion=8.0-rc-5
+net.twisterrob.gradle.runner.gradleVersion=7.4
 # AGP 3.3.3-4.2.2 -> Java 8; AGP 7.0.0-7.4.0 -> Java 11; AGP 8.0.0- -> Java 17
 net.twisterrob.test.gradle.javaHomeEnv=JAVA11_HOME
 

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -6,6 +6,7 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import com.android.build.gradle.internal.lint.AndroidLintGlobalTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
 import com.android.build.gradle.internal.tasks.ProguardConfigurableTask
 import com.android.build.gradle.internal.tasks.R8Task
 import net.twisterrob.gradle.common.AGPVersions
@@ -143,9 +144,11 @@ class AndroidMinificationPlugin : BasePlugin() {
 
 	private fun lintDependsOnGenerateRulesTask(task: TaskProvider<Task>) {
 		if (AGPVersions.CLASSPATH >= AGPVersions.v70x) {
+			println(task)
 			// REPORT allow tasks to generate ProGuard files, this must be possible because aapt generates one.
 			project.tasks.withType<AndroidLintGlobalTask>().configureEach { it.mustRunAfter(task) }
 			project.tasks.withType<AndroidLintAnalysisTask>().configureEach { it.mustRunAfter(task) }
+//			project.tasks.withType<LintModelWriterTask>().configureEach { it.mustRunAfter(task) }
 		}
 	}
 

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -144,11 +144,10 @@ class AndroidMinificationPlugin : BasePlugin() {
 
 	private fun lintDependsOnGenerateRulesTask(task: TaskProvider<Task>) {
 		if (AGPVersions.CLASSPATH >= AGPVersions.v70x) {
-			println(task)
 			// REPORT allow tasks to generate ProGuard files, this must be possible because aapt generates one.
 			project.tasks.withType<AndroidLintGlobalTask>().configureEach { it.mustRunAfter(task) }
 			project.tasks.withType<AndroidLintAnalysisTask>().configureEach { it.mustRunAfter(task) }
-//			project.tasks.withType<LintModelWriterTask>().configureEach { it.mustRunAfter(task) }
+			project.tasks.withType<LintModelWriterTask>().configureEach { it.mustRunAfter(task) }
 		}
 	}
 

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.junitpioneer.jupiter.Issue
 import java.io.File
 
 /**
@@ -288,6 +289,7 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 		assertThat(gradle.mergedProguardConfiguration("release").readText(), containsString(dummyProguardClass))
 	}
 
+	@Issue("https://github.com/TWiStErRob/net.twisterrob.gradle/issues/214")
 	@Test fun `extract task wires with Android Lint correctly`() {
 		gradle.settingsFile.appendText("include ':lib'")
 
@@ -308,8 +310,9 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 			apply plugin: 'net.twisterrob.gradle.plugin.android-app'
 			dependencies { implementation project(':lib') }
 			android.lint.checkDependencies = true
+			tasks.named("lint") { dependsOn("lintRelease") } // By default this is not the case in AGP 7.x.
 		""".trimIndent()
-		val result = gradle.run(script, "build").build()
+		val result = gradle.run(script, "extractMinificationRules", "build").build()
 
 		result.assertSuccess(":extractMinificationRules")
 		result.assertSuccess(":lintRelease")

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -18,6 +18,7 @@ import org.hamcrest.Matchers.not
 import org.hamcrest.io.FileMatchers.anExistingFile
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -286,6 +287,48 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 		// check if submodule config is included
 		assertThat(gradle.mergedProguardConfiguration("release").readText(), containsString(dummyProguardClass))
 	}
+
+	@Test fun `extract task wires with Android Lint correctly`() {
+//		val minification = Minification.R8
+		@Language("java")
+		val someClass = """
+			package ${packageName};
+			public class SomeClass {
+				@androidx.annotation.Keep
+				public void usedMethod() { }
+				// no reason to -keep it, it'll be optimized away
+				public void unusedMethod() { }
+			}
+		""".trimIndent()
+		gradle.file(someClass, "src/main/java/${packageFolder}/SomeClass.java")
+
+		@Language("properties")
+		val properties = """
+			android.useAndroidX=true
+		""".trimIndent()
+		gradle.root.resolve("gradle.properties").appendText(properties)
+
+		@Language("gradle")
+		val script = """
+			println(gradle.startParameter.isParallelProjectExecutionEnabled())
+			apply plugin: 'net.twisterrob.gradle.plugin.android-app'
+			dependencies {
+				implementation 'androidx.annotation:annotation:1.1.0'
+			}
+		""".trimIndent()
+
+		val result = gradle.run(script, "extractProguardFiles", "extractMinificationRules", "lintRelease").build()
+
+		result.assertSuccess(":lintRelease")
+		result.assertNoTask(":lintDebug")
+		val releaseMethods = gradle.root.apk("release").toDexParser().listMethods()
+		val debugMethods = gradle.root.apk("debug").toDexParser().listMethods()
+		val unusedMethod = dexMethod("${packageName}.SomeClass", "unusedMethod")
+		val usedMethod = dexMethod("${packageName}.SomeClass", "usedMethod")
+		assertThat(debugMethods, hasItems(unusedMethod, usedMethod))
+		assertThat(releaseMethods, allOf(hasItem(usedMethod), not(hasItem(unusedMethod))))
+	}
+
 
 	private fun BuildResult.assertExtractMinificationRulesRunsSuccessfully() {
 		this.assertSuccess(":extractMinificationRules")

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -309,14 +309,12 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 		val script = """
 			apply plugin: 'net.twisterrob.gradle.plugin.android-app'
 			dependencies { implementation project(':lib') }
-			android.lint.checkDependencies = true
+			android.lintOptions.checkDependencies = true
 			tasks.named("lint") { dependsOn("lintRelease") } // By default this is not the case in AGP 7.x.
 		""".trimIndent()
 		val result = gradle.run(script, "extractMinificationRules", "build").build()
 
 		result.assertSuccess(":extractMinificationRules")
-		result.assertSuccess(":lintRelease")
-		result.assertSuccess(":lintDebug")
 		result.assertSuccess(":lint")
 	}
 


### PR DESCRIPTION
These tasks only exist when `checkDependencies = true`.