### PR TITLE
Fix #233: Migrate AndroidManifest.xml to namespace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,14 +297,29 @@ nexusPublishing {
 
 idea {
 	module {
-		val excludes = listOf(
+		val unpackagedResources = allprojects
+			.map { it.projectDir.relativeTo(rootDir).resolve("build/unPackagedTestResources").toString() }
+		val examples = listOf(
 			"docs/examples/local/.gradle",
 			"docs/examples/local/build",
 			"docs/examples/release/.gradle",
 			"docs/examples/release/build",
 			"docs/examples/snapshot/.gradle",
 			"docs/examples/snapshot/build",
-		) + allprojects.map { it.projectDir.relativeTo(rootDir).resolve("build/unPackagedTestResources").toString() } 
+		)
+		val debuggers = file("docs/debug")
+			.listFiles { file: File -> file.isDirectory }
+			.flatMap { 
+				listOf(
+					it.resolve(".gradle"),
+					it.resolve("build"),
+					it.resolve("buildSrc/.gradle"),
+					it.resolve("buildSrc/build"),
+					it.resolve(".idea")
+				)
+			}
+			.map { it.path }
+		val excludes = examples + debuggers + unpackagedResources 
 		excludeDirs.addAll(excludes.map { rootDir.resolve(it) })
 	}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,8 +297,6 @@ nexusPublishing {
 
 idea {
 	module {
-		val unpackagedResources = allprojects
-			.map { it.projectDir.relativeTo(rootDir).resolve("build/unPackagedTestResources").toString() }
 		val examples = listOf(
 			"docs/examples/local/.gradle",
 			"docs/examples/local/build",
@@ -306,21 +304,21 @@ idea {
 			"docs/examples/release/build",
 			"docs/examples/snapshot/.gradle",
 			"docs/examples/snapshot/build",
-		)
-		val debuggers = file("docs/debug")
+		).map { rootDir.resolve(it) }
+		val debuggers = rootDir
+			.resolve("docs/debug")
 			.listFiles { file: File -> file.isDirectory }
-			.flatMap { 
+			.flatMap { debugDir ->
 				listOf(
-					it.resolve(".gradle"),
-					it.resolve("build"),
-					it.resolve("buildSrc/.gradle"),
-					it.resolve("buildSrc/build"),
-					it.resolve(".idea")
+					debugDir.resolve(".gradle"),
+					debugDir.resolve("build"),
+					debugDir.resolve("buildSrc/.gradle"),
+					debugDir.resolve("buildSrc/build"),
+					debugDir.resolve(".idea"),
 				)
 			}
-			.map { it.path }
-		val excludes = examples + debuggers + unpackagedResources 
-		excludeDirs.addAll(excludes.map { rootDir.resolve(it) })
+		val unpackagedResources = allprojects.map { it.projectDir.resolve("build/unPackagedTestResources") }
+		excludeDirs.addAll(examples + debuggers + unpackagedResources)
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,26 +297,22 @@ nexusPublishing {
 
 idea {
 	module {
-		val examples = listOf(
-			"docs/examples/local/.gradle",
-			"docs/examples/local/build",
-			"docs/examples/release/.gradle",
-			"docs/examples/release/build",
-			"docs/examples/snapshot/.gradle",
-			"docs/examples/snapshot/build",
-		).map { rootDir.resolve(it) }
+		fun excludedInProject(dir: File): List<File> =
+			listOf(
+				dir.resolve(".gradle"),
+				dir.resolve("build"),
+				dir.resolve("buildSrc/.gradle"),
+				dir.resolve("buildSrc/build"),
+				dir.resolve(".idea"),
+			)
+
+		val examples = listOf("local", "release", "snapshot")
+			.map { rootDir.resolve("docs/examples").resolve(it) }
+			.flatMap(::excludedInProject)
 		val debuggers = rootDir
 			.resolve("docs/debug")
 			.listFiles { file: File -> file.isDirectory }
-			.flatMap { debugDir ->
-				listOf(
-					debugDir.resolve(".gradle"),
-					debugDir.resolve("build"),
-					debugDir.resolve("buildSrc/.gradle"),
-					debugDir.resolve("buildSrc/build"),
-					debugDir.resolve(".idea"),
-				)
-			}
+			.flatMap(::excludedInProject)
 		val unpackagedResources = allprojects.map { it.projectDir.resolve("build/unPackagedTestResources") }
 		excludeDirs.addAll(examples + debuggers + unpackagedResources)
 	}

--- a/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
+++ b/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
@@ -103,8 +103,7 @@ class CheckStylePluginTest : BaseIntgTest() {
 		val exceptions = arrayOf(
 			// These tasks are not generated because their modules are special.
 			":test:checkstyleRelease",
-			// :feature module is deprecated in AGP 4.x and support for it was removed.
-			*tasksIn(arrayOf(":feature", ":base"), "checkstyleEach", "checkstyleRelease", "checkstyleDebug")
+			*tasksIn(arrayOf(":base"), "checkstyleEach", "checkstyleRelease", "checkstyleDebug")
 		)
 		assertThat(
 			result.taskPaths(TaskOutcome.NO_SOURCE),

--- a/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
+++ b/checkers/checkstyle/src/test/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePluginTest.kt
@@ -134,16 +134,11 @@ class CheckStylePluginTest : BaseIntgTest() {
 			@Language("gradle")
 			val subProject = """
 				apply plugin: 'com.android.library'
-			""".trimIndent()
-
-			@Language("xml")
-			val manifest = """
-				<manifest package="project${modulePath.replace(":", ".")}" />
+				android.namespace = "project${modulePath.replace(":", ".")}"
 			""".trimIndent()
 
 			val subPath = modulePath.split(":").toTypedArray()
 			gradle.file(subProject, *subPath, "build.gradle")
-			gradle.file(manifest, *subPath, "src", "main", "AndroidManifest.xml")
 		}
 
 		gradle.file(checkstyle.empty.config, "config", "checkstyle", "checkstyle.xml")
@@ -174,15 +169,6 @@ class CheckStylePluginTest : BaseIntgTest() {
 	}
 
 	@Test fun `applies to individual subprojects`() {
-		@Language("gradle")
-		val subProjectNotApplied = """
-			apply plugin: 'com.android.library'
-		""".trimIndent()
-		@Language("gradle")
-		val subProjectApplied = """
-			apply plugin: 'net.twisterrob.gradle.plugin.checkstyle'
-			apply plugin: 'com.android.library'
-		""".trimIndent()
 
 		val modules = arrayOf(
 			":module1",
@@ -196,15 +182,22 @@ class CheckStylePluginTest : BaseIntgTest() {
 		modules.forEach { module ->
 			gradle.settingsFile.appendText("include '${module}'${endl}")
 
-			val subProject = if (module in applyTo) subProjectApplied else subProjectNotApplied
-			@Language("xml")
-			val manifest = """
-				<manifest package="project${module.replace(":", ".")}" />
-			""".trimIndent()
+			@Suppress("MandatoryBracesIfStatements") // Language annotation doesn't work on implicit block return.
+			@Language("gradle")
+			val subProject = if (module in applyTo)
+				"""
+					apply plugin: 'net.twisterrob.gradle.plugin.checkstyle'
+					apply plugin: 'com.android.library'
+					android.namespace = "project${module.replace(":", ".")}"
+				""".trimIndent()
+			else
+				"""
+					apply plugin: 'com.android.library'
+					android.namespace = "project${module.replace(":", ".")}"
+				""".trimIndent()
 
 			val subPath = module.split(":").toTypedArray()
 			gradle.file(subProject, *subPath, "build.gradle")
-			gradle.file(manifest, *subPath, "src", "main", "AndroidManifest.xml")
 		}
 
 		gradle.file(checkstyle.empty.config, "config", "checkstyle", "checkstyle.xml")

--- a/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
+++ b/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
@@ -107,8 +107,7 @@ class PmdPluginTest : BaseIntgTest() {
 		val exceptions = arrayOf(
 			// These tasks are not generated because their modules are special.
 			":test:pmdRelease",
-			// :feature module is deprecated in AGP 4.x and support for it was removed.
-			*tasksIn(arrayOf(":feature", ":base"), "pmdEach", "pmdRelease", "pmdDebug")
+			*tasksIn(arrayOf(":base"), "pmdEach", "pmdRelease", "pmdDebug")
 		)
 		assertThat(
 			result.taskPaths(TaskOutcome.SUCCESS),

--- a/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
+++ b/checkers/pmd/src/test/kotlin/net/twisterrob/gradle/pmd/PmdPluginTest.kt
@@ -94,6 +94,10 @@ class PmdPluginTest : BaseIntgTest() {
 		// ":instant" is not supported yet, and won't be since it's deprecated in 3.6.x.
 		// TODO add :dynamic-feature
 		val modules = arrayOf(":app", ":library", ":library:nested", ":test")
+		// Add empty manifest, so PMD task picks it up.
+		gradle.file("<manifest />", "library", "src", "main", "AndroidManifest.xml")
+		gradle.file("<manifest />", "library", "nested", "src", "main", "AndroidManifest.xml")
+		gradle.file("<manifest />", "test", "src", "main", "AndroidManifest.xml")
 
 		val result = gradle.runBuild {
 			basedOn("android-all_kinds")
@@ -139,6 +143,8 @@ class PmdPluginTest : BaseIntgTest() {
 
 			val subPath = modulePath.split(":").toTypedArray()
 			gradle.file(subProject, *subPath, "build.gradle")
+			// Add empty manifest, so PMD task picks it up.
+			gradle.file("<manifest />", *subPath, "src", "main", "AndroidManifest.xml")
 		}
 
 		gradle.file(pmd.empty.config, "config", "pmd", "pmd.xml")
@@ -169,7 +175,6 @@ class PmdPluginTest : BaseIntgTest() {
 	}
 
 	@Test fun `applies to individual subprojects`() {
-
 		val modules = arrayOf(
 			":module1",
 			":module2",
@@ -198,6 +203,8 @@ class PmdPluginTest : BaseIntgTest() {
 
 			val subPath = modulePath.split(":").toTypedArray()
 			gradle.file(subProject, *subPath, "build.gradle")
+			// Add empty manifest, so PMD task picks it up.
+			gradle.file("<manifest />", *subPath, "src", "main", "AndroidManifest.xml")
 		}
 
 		gradle.file(pmd.empty.config, "config", "pmd", "pmd.xml")

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/AndroidVariantApplier.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/AndroidVariantApplier.kt
@@ -21,10 +21,6 @@ class AndroidVariantApplier(val project: Project) {
 		project.plugins.withId("com.android.library") {
 			variantsClosure.execute(android<LibraryExtension>().libraryVariants)
 		}
-		project.plugins.withId("com.android.feature") {
-			// These types of feature modules were deprecated and removed in AGP 4.x.
-			//variantsClosure.execute(android<FeatureExtension>().featureVariants)
-		}
 		project.plugins.withId("com.android.dynamic-feature") {
 			variantsClosure.execute(android<AppExtension>().applicationVariants)
 		}

--- a/docs/debug/agp704-gradle702/build.gradle
+++ b/docs/debug/agp704-gradle702/build.gradle
@@ -6,5 +6,6 @@ repositories {
 }
 
 android {
+	namespace = "test.project"
 	compileSdkVersion 'android-30'
 }

--- a/docs/debug/agp704-gradle702/src/main/AndroidManifest.xml
+++ b/docs/debug/agp704-gradle702/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="test.project" />
+<manifest />

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -65,7 +65,7 @@ run {
 	val sharedCodeFolder: File = file("src/main/kotlin-shared")
 	kotlin.sourceSets.named("main").configure { kotlin.srcDir(sharedCodeFolder) }
 	// This is to make sure that IDEA doesn't mess things up with duplicated source roots.
-	val copyReusableSources = tasks.register<Copy>("copyReusableSources") {
+	val copyReusableSources = tasks.register<Sync>("copyReusableSources") {
 		// More robust: gradle.parent!!.rootProject.project(":plugin:settings").file("src/main/kotlin-shared")
 		// but at this point in the lifecycle the parent (including build) rootProject build is not available yet.
 		from(rootProject.file("../../plugin/settings/src/main/kotlin-shared"))

--- a/gradle/plugins/src/main/kotlin/testResources.kt
+++ b/gradle/plugins/src/main/kotlin/testResources.kt
@@ -12,6 +12,7 @@ fun Project.exposeTestResources() {
 	val packageTestResources = tasks.register<Copy>("packageTestResources") {
 		from(project.java.sourceSets.named("test").map { it.resources })
 		into(project.layout.buildDirectory.dir("packagedTestResources"))
+		doFirst { delete(destinationDir) }
 	}
 	val testResources = configurations.create("exposedTestResources")
 	artifacts {
@@ -33,6 +34,7 @@ fun Project.pullTestResourcesFrom(project: ProjectDependency) {
 	val copyResources = tasks.register<Copy>("copyExposedTestResources") {
 		from(testResources)
 		into(layout.buildDirectory.dir("unPackagedTestResources"))
+		doFirst { delete(destinationDir) }
 	}
 	java.sourceSets.named("test").configure {
 		resources.srcDir(copyResources)

--- a/gradle/plugins/src/main/kotlin/testResources.kt
+++ b/gradle/plugins/src/main/kotlin/testResources.kt
@@ -1,6 +1,6 @@
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Sync
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.register
@@ -9,10 +9,9 @@ import org.gradle.kotlin.dsl.register
  * Expose test resources so another project can use the same files without hacking.
  */
 fun Project.exposeTestResources() {
-	val packageTestResources = tasks.register<Copy>("packageTestResources") {
+	val packageTestResources = tasks.register<Sync>("packageTestResources") {
 		from(project.java.sourceSets.named("test").map { it.resources })
 		into(project.layout.buildDirectory.dir("packagedTestResources"))
-		doFirst { delete(destinationDir) }
 	}
 	val testResources = configurations.create("exposedTestResources")
 	artifacts {
@@ -31,10 +30,9 @@ fun Project.pullTestResourcesFrom(project: ProjectDependency) {
 	// This copy is necessary to deduplicate source roots and prevent IDEA warning:
 	// > Duplicate content roots detected:
 	// > Path [test/src/test/resources] of module [checkstyle.test] was removed from modules [pmd.test, quality.test]
-	val copyResources = tasks.register<Copy>("copyExposedTestResources") {
+	val copyResources = tasks.register<Sync>("copyExposedTestResources") {
 		from(testResources)
 		into(layout.buildDirectory.dir("unPackagedTestResources"))
-		doFirst { delete(destinationDir) }
 	}
 	java.sourceSets.named("test").configure {
 		resources.srcDir(copyResources)

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
@@ -15,7 +15,7 @@ import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * @see /android-plugin_app/src/main/AndroidManifest.xml
+ * @see /android-plugin_app/build.gradle
  */
 const val packageName: String = "net.twisterrob.gradle.test_app"
 

--- a/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/android-plugin_app/build.gradle
+++ b/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/android-plugin_app/build.gradle
@@ -18,6 +18,9 @@ repositories {
 // Each test will apply it if and when necessary through net.twisterrob.android-* plugins.
 project.plugins.withType(com.android.build.gradle.internal.plugins.BasePlugin).configureEach {
 	android {
+		// See also net.twisterrob.gradle.android.GradleTestHelpersKt.packageName.
+		namespace = "net.twisterrob.gradle.test_app"
+
 		compileSdkVersion '@net.twisterrob.test.android.compileSdkVersion@'
 	}
 }

--- a/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/android-plugin_app/src/main/AndroidManifest.xml
+++ b/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/android-plugin_app/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<!-- See also net.twisterrob.gradle.android.GradleTestHelpersKt.packageName. -->
-<manifest package="net.twisterrob.gradle.test_app" />
+<manifest />

--- a/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/AndroidBuildPluginIntgTest.kt
+++ b/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/AndroidBuildPluginIntgTest.kt
@@ -220,6 +220,7 @@ class AndroidBuildPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val appGradle = """
 			apply plugin: 'net.twisterrob.gradle.plugin.android-app'
+			android.namespace = "${packageName}"
 			afterEvaluate {
 				println(android.compileSdkVersion)
 			}

--- a/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/tasks/AndroidInstallRunnerTaskIntgTest.kt
+++ b/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/tasks/AndroidInstallRunnerTaskIntgTest.kt
@@ -11,7 +11,6 @@ import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.assertSkipped
 import net.twisterrob.gradle.test.assertSuccess
-import net.twisterrob.gradle.test.delete
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -34,7 +33,7 @@ class AndroidInstallRunnerTaskIntgTest : BaseAndroidIntgTest() {
 
 		@Language("xml")
 		val androidManifest = """
-			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="$packageName">
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 				<application>
 					<activity android:name=".MainActivity">
 						<intent-filter>
@@ -45,7 +44,6 @@ class AndroidInstallRunnerTaskIntgTest : BaseAndroidIntgTest() {
 				</application>
 			</manifest>
 		""".trimIndent()
-		gradle.delete("src/main/AndroidManifest.xml")
 		gradle.file(androidManifest, "src/main/AndroidManifest.xml")
 
 		@Language("java")
@@ -59,10 +57,11 @@ class AndroidInstallRunnerTaskIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val script = """
 			apply plugin: 'net.twisterrob.gradle.plugin.android-app'
+			android.namespace = "${packageName}"
 			afterEvaluate {
 				// Don't always try to install the APK, as we may have no emulator,
 				// but still assemble the APK, as the run task needs AndroidManifest.xml.
-				tasks.installDebug.enabled = $hasDevices
+				tasks.installDebug.enabled = ${hasDevices}
 			}
 		""".trimIndent()
 

--- a/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/tasks/AndroidInstallRunnerTaskIntgTest.kt
+++ b/plugin/building/src/test/kotlin/net/twisterrob/gradle/android/tasks/AndroidInstallRunnerTaskIntgTest.kt
@@ -11,6 +11,7 @@ import net.twisterrob.gradle.test.assertHasOutputLine
 import net.twisterrob.gradle.test.assertNoOutputLine
 import net.twisterrob.gradle.test.assertSkipped
 import net.twisterrob.gradle.test.assertSuccess
+import net.twisterrob.gradle.test.delete
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -44,6 +45,7 @@ class AndroidInstallRunnerTaskIntgTest : BaseAndroidIntgTest() {
 				</application>
 			</manifest>
 		""".trimIndent()
+		gradle.delete("src/main/AndroidManifest.xml")
 		gradle.file(androidManifest, "src/main/AndroidManifest.xml")
 
 		@Language("java")

--- a/plugin/languages/src/test/kotlin/net/twisterrob/gradle/android/KotlinPluginIntgTest.kt
+++ b/plugin/languages/src/test/kotlin/net/twisterrob/gradle/android/KotlinPluginIntgTest.kt
@@ -76,14 +76,10 @@ class KotlinPluginIntgTest : BaseAndroidIntgTest() {
 			dependencies {
 				implementation("junit:junit:${Version.id()}")
 			}
+			android.namespace = "${packageName}.test"
 			android.targetProjectPath = ':'
 		""".trimIndent()
 		gradle.file(appScript, "test", "build.gradle")
-		@Language("xml")
-		val androidManifest = """
-			<manifest package="${packageName}.test" />
-		""".trimIndent()
-		gradle.file(androidManifest, "test/src/main/AndroidManifest.xml")
 
 		@Language("gradle")
 		val script = """

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidMinificationPluginIntgTest.kt
@@ -250,14 +250,10 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val libGradle = """
 			apply plugin: 'net.twisterrob.gradle.plugin.android-library'
+			android.namespace = "${packageName}.lib"
 			android.defaultConfig.consumerProguardFile 'proguard.pro'
 		""".trimIndent()
 		gradle.file(libGradle, "lib", "build.gradle")
-		@Language("xml")
-		val androidManifest = """
-			<manifest package="${packageName}.lib" />
-		""".trimIndent()
-		gradle.file(androidManifest, "lib", "src", "main", "AndroidManifest.xml")
 		val dummyProguardClass = "some.dummy.thing.SoItShowsUpInTheMergeConfiguration"
 
 		@Language("proguard")
@@ -285,14 +281,9 @@ class AndroidMinificationPluginIntgTest : BaseAndroidIntgTest() {
 		@Language("gradle")
 		val libGradle = """
 			apply plugin: 'net.twisterrob.gradle.plugin.android-library'
+			android.namespace = "${packageName}.lib"
 		""".trimIndent()
 		gradle.file(libGradle, "lib", "build.gradle")
-
-		@Language("xml")
-		val libManifest = """
-			<manifest package="${packageName}.lib" />
-		""".trimIndent()
-		gradle.file(libManifest, "lib", "src", "main", "AndroidManifest.xml")
 
 		@Language("gradle")
 		val script = """

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/LintPluginTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/LintPluginTest.kt
@@ -46,21 +46,12 @@ class LintPluginTest : BaseIntgTest() {
 			@Language("gradle")
 			val subProject = """
 				apply plugin: 'com.android.library'
-				android {
-					lintOptions {
-						check = [] // nothing
-					}
-				}
-			""".trimIndent()
-
-			@Language("xml")
-			val manifest = """
-				<manifest package="project.${module}" />
+				android.namespace = "project.${module}"
+				android.lintOptions.check = [] // nothing
 			""".trimIndent()
 
 			gradle.file(subProject, module, "build.gradle")
 			gradle.settingsFile.appendText("include ':${module}'${endl}")
-			gradle.file(manifest, module, "src", "main", "AndroidManifest.xml")
 		}
 
 		@Language("gradle")
@@ -307,23 +298,14 @@ class LintPluginTest : BaseIntgTest() {
 			@Language("gradle")
 			val subProject = """
 				apply plugin: 'com.android.library'
-				android {
-					lintOptions {
-						//noinspection GroovyAssignabilityCheck
-						check = ['LongLogTag']
-					}
-				}
-			""".trimIndent()
-
-			@Language("xml")
-			val manifest = """
-				<manifest package="project.${module}" />
+				android.namespace = "project.${module}"
+				//noinspection GroovyAssignabilityCheck
+				android.lintOptions.check = ['LongLogTag']
 			""".trimIndent()
 
 			gradle.file(subProject, module, "build.gradle")
 			gradle.settingsFile.appendText("include ':${module}'${endl}")
 			gradle.file(lintViolation, module, "src", "main", "java", "fail1.java")
-			gradle.file(manifest, module, "src", "main", "AndroidManifest.xml")
 		}
 	}
 

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
@@ -192,18 +192,14 @@ class GlobalTestFinalizerTaskTest : BaseIntgTest() {
 			@Language("gradle")
 			val subProject = """
 				apply plugin: 'com.android.library'
+				android.namespace = "project${modulePath.replace(":", ".")}"
 				dependencies {
 					testImplementation 'junit:junit:${Version.id()}'
 				}
 			""".trimIndent()
-			@Language("xml")
-			val manifest = """
-				<manifest package="project${modulePath.replace(":", ".")}" />
-			""".trimIndent()
 
 			val subPath = modulePath.split(":").toTypedArray()
 			gradle.file(subProject, *subPath, "build.gradle")
-			gradle.file(manifest, *subPath, "src", "main", "AndroidManifest.xml")
 			if (modulePath in applyTo) {
 				gradle.file(testFile, *subPath, "src", "test", "java", "Tests.java")
 			}

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
@@ -4,7 +4,10 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 
 inline fun GradleRunnerRule.runBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =
-	this.block().build()
+	this.block().build().also {
+		// STOPSHIP
+		it.assertNoOutputLine("Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.")
+	}
 
 inline fun GradleRunnerRule.runFailingBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =
 	this.block().buildAndFail()

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
@@ -4,9 +4,9 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 
 inline fun GradleRunnerRule.runBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =
-	this.block().build().also {
+	this.block().build().apply {
 		// STOPSHIP
-		it.assertNoOutputLine("Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.")
+		assertNoOutputLine("Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.")
 	}
 
 inline fun GradleRunnerRule.runFailingBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestStyle.kt
@@ -4,10 +4,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 
 inline fun GradleRunnerRule.runBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =
-	this.block().build().apply {
-		// STOPSHIP
-		assertNoOutputLine("Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.")
-	}
+	this.block().build()
 
 inline fun GradleRunnerRule.runFailingBuild(block: GradleRunnerRule.() -> GradleRunner): BuildResult =
 	this.block().buildAndFail()

--- a/test/src/test/resources/android-all_kinds/app/build.gradle
+++ b/test/src/test/resources/android-all_kinds/app/build.gradle
@@ -1,1 +1,5 @@
 apply plugin: 'com.android.application'
+
+android {
+	namespace = "test.project.app"
+}

--- a/test/src/test/resources/android-all_kinds/app/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/app/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/test/src/test/resources/android-all_kinds/app/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/app/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.app" />

--- a/test/src/test/resources/android-all_kinds/dyanamic-feature/build.gradle
+++ b/test/src/test/resources/android-all_kinds/dyanamic-feature/build.gradle
@@ -1,1 +1,5 @@
 apply plugin: 'com.android.dynamic-feature'
+
+android {
+	namespace = "test.project.dynamic_feature"
+}

--- a/test/src/test/resources/android-all_kinds/dyanamic-feature/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/dyanamic-feature/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.dynamic_feature" />

--- a/test/src/test/resources/android-all_kinds/library/build.gradle
+++ b/test/src/test/resources/android-all_kinds/library/build.gradle
@@ -3,3 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
 	implementation project('nested')
 }
+
+android {
+	namespace = "test.project.library"
+}

--- a/test/src/test/resources/android-all_kinds/library/nested/build.gradle
+++ b/test/src/test/resources/android-all_kinds/library/nested/build.gradle
@@ -1,1 +1,5 @@
 apply plugin: 'com.android.library'
+
+android {
+	namespace = "test.project.library.nested"
+}

--- a/test/src/test/resources/android-all_kinds/library/nested/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/library/nested/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.library.nested" />

--- a/test/src/test/resources/android-all_kinds/library/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/library/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.library" />

--- a/test/src/test/resources/android-all_kinds/test/build.gradle
+++ b/test/src/test/resources/android-all_kinds/test/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.test'
 
 android {
+	namespace = "test.project.test"
 	targetProjectPath ':app'
 }

--- a/test/src/test/resources/android-all_kinds/test/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-all_kinds/test/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.test" />

--- a/test/src/test/resources/android-root_app/build.gradle
+++ b/test/src/test/resources/android-root_app/build.gradle
@@ -16,5 +16,6 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
+	namespace = "test.project"
 	compileSdkVersion '@net.twisterrob.test.android.compileSdkVersion@'
 }

--- a/test/src/test/resources/android-root_app/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-root_app/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="test.project" />
+<manifest />

--- a/test/src/test/resources/android-single_module/build.gradle
+++ b/test/src/test/resources/android-single_module/build.gradle
@@ -17,6 +17,7 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+	namespace = "test.project"
 	compileSdkVersion '@net.twisterrob.test.android.compileSdkVersion@'
 }
 

--- a/test/src/test/resources/android-single_module/module/build.gradle
+++ b/test/src/test/resources/android-single_module/module/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 
 android {
+	namespace = "test.project.module"
 	compileSdkVersion '@net.twisterrob.test.android.compileSdkVersion@'
 }

--- a/test/src/test/resources/android-single_module/module/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-single_module/module/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project.module" />

--- a/test/src/test/resources/android-single_module/src/main/AndroidManifest.xml
+++ b/test/src/test/resources/android-single_module/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="test.project" />


### PR DESCRIPTION
Fixes #233, contributes to #369

Empty manifest is required for apps, otherwise:
```
* What went wrong:
Execution failed for task ':app:generateDebugBuildConfig'.
> Error while evaluating property 'versionCode' of task ':app:generateDebugBuildConfig'.
   > Failed to calculate the value of task ':app:generateDebugBuildConfig' property 'versionCode'.
      > Manifest file does not exist: C:\Users\TWiStEr\AppData\Local\Temp\junit12882942920266785441\app\src\main\AndroidManifest.xml

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:generateDebugBuildConfig'.
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:38)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:338)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:325)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:318)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:304)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:463)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:49)
Caused by: org.gradle.api.internal.tasks.properties.PropertyEvaluationException: Error while evaluating property 'versionCode' of task ':app:generateDebugBuildConfig'.
	at org.gradle.api.internal.tasks.properties.InputParameterUtils.prepareInputParameterValue(InputParameterUtils.java:32)
	at org.gradle.api.internal.tasks.execution.TaskExecution.lambda$visitRegularInputs$1(TaskExecution.java:315)
	at org.gradle.internal.execution.impl.DefaultInputFingerprinter$InputCollectingVisitor.visitInputProperty(DefaultInputFingerprinter.java:103)
	at org.gradle.api.internal.tasks.execution.TaskExecution.visitRegularInputs(TaskExecution.java:313)
	at org.gradle.internal.execution.impl.DefaultInputFingerprinter.fingerprintInputProperties(DefaultInputFingerprinter.java:63)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.captureExecutionStateWithOutputs(CaptureStateBeforeExecutionStep.java:123)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.lambda$captureExecutionState$1(CaptureStateBeforeExecutionStep.java:82)
	at org.gradle.internal.execution.steps.BuildOperationStep$1.call(BuildOperationStep.java:37)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.internal.execution.steps.BuildOperationStep.operation(BuildOperationStep.java:34)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.captureExecutionState(CaptureStateBeforeExecutionStep.java:76)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.lambda$execute$0(CaptureStateBeforeExecutionStep.java:70)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:70)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:45)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNonEmptySources(SkipEmptyWorkStep.java:177)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:81)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:53)
	at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:32)
	at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:21)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:36)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:23)
	at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:75)
	at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:41)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:32)
	at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:287)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:30)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:21)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:37)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:27)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:42)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:31)
	at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:64)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:146)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:135)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:338)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:325)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:318)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:304)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:463)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:49)
Caused by: org.gradle.api.internal.provider.AbstractProperty$PropertyQueryException: Failed to calculate the value of task ':app:generateDebugBuildConfig' property 'versionCode'.
	at org.gradle.api.internal.provider.AbstractProperty.finalizeNow(AbstractProperty.java:248)
	at org.gradle.api.internal.provider.AbstractProperty.beforeRead(AbstractProperty.java:239)
	at org.gradle.api.internal.provider.AbstractProperty.calculateOwnValue(AbstractProperty.java:135)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.getOrNull(AbstractMinimalProvider.java:98)
	at org.gradle.api.internal.provider.ProviderResolutionStrategy$1.resolve(ProviderResolutionStrategy.java:27)
	at org.gradle.util.internal.DeferredUtil.unpack(DeferredUtil.java:59)
	at org.gradle.util.internal.DeferredUtil.unpackOrNull(DeferredUtil.java:49)
	at org.gradle.api.internal.tasks.properties.InputParameterUtils.prepareInputParameterValue(InputParameterUtils.java:38)
	at org.gradle.api.internal.tasks.properties.InputParameterUtils.prepareInputParameterValue(InputParameterUtils.java:30)
	... 67 more
Caused by: com.android.builder.errors.EvalIssueException: Manifest file does not exist: C:\Users\TWiStEr\AppData\Local\Temp\junit12882942920266785441\app\src\main\AndroidManifest.xml
	at com.android.builder.errors.IssueReporter.reportError(IssueReporter.kt:112)
	at com.android.builder.errors.IssueReporter.reportError$default(IssueReporter.kt:108)
	at com.android.build.gradle.internal.manifest.ManifestDataKt.parseManifest(ManifestData.kt:194)
	at com.android.build.gradle.internal.manifest.LazyManifestParser$manifestData$2$provider$1.transform(LazyManifestParser.kt:38)
	at com.android.build.gradle.internal.manifest.LazyManifestParser$manifestData$2$provider$1.transform(LazyManifestParser.kt:37)
	at org.gradle.api.internal.provider.ValueSupplier$Present.transform(ValueSupplier.java:541)
	at org.gradle.api.internal.provider.TransformBackedProvider.mapValue(TransformBackedProvider.java:91)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:83)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:82)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.withFinalValue(AbstractMinimalProvider.java:164)
	at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:133)
	at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:26)
	at org.gradle.api.internal.provider.AbstractProperty.finalizeNow(AbstractProperty.java:245)
	at org.gradle.api.internal.provider.AbstractProperty.beforeRead(AbstractProperty.java:239)
	at org.gradle.api.internal.provider.AbstractProperty.calculateOwnValue(AbstractProperty.java:135)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:82)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:82)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.DefaultProperty.calculateValueFrom(DefaultProperty.java:128)
	at org.gradle.api.internal.provider.DefaultProperty.calculateValueFrom(DefaultProperty.java:26)
	at org.gradle.api.internal.provider.AbstractProperty.doCalculateValue(AbstractProperty.java:142)
	at org.gradle.api.internal.provider.AbstractProperty.calculateOwnValue(AbstractProperty.java:136)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.withFinalValue(AbstractMinimalProvider.java:164)
	at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:133)
	at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:26)
	at org.gradle.api.internal.provider.AbstractProperty.finalizeNow(AbstractProperty.java:245)
	... 75 more
```