### PR TITLE
Fix #155: Improve configuration cache compatibility

### DIFF
--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptTestMetadata.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptTestMetadata.kt
@@ -22,6 +22,7 @@ abstract class InitScriptTestMetadata : DefaultTask() {
 	init {
 		group = "Plugin development" // JavaGradlePluginPlugin.PLUGIN_DEVELOPMENT_GROUP
 		description = "Generates the metadata for init script used in plugin integration tests."
+		@Suppress("LeakingThis")
 		output.convention(project.layout.buildDirectory.file("initscript-test-metadata.properties"))
 	}
 

--- a/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
+++ b/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
@@ -12,12 +12,11 @@ class GradlePlugin : BasePlugin() {
 
 		project.tasks.register<Task>("debugWrapper") {
 			val debugFile = project.file("gradled.bat")
+			val wrapperFile = project.file("gradlew.bat")
 			description = "Generates a ${debugFile.name} script to start a Gradle task in debug mode."
 			group = "Build Setup"
+			inputs.file(wrapperFile).skipWhenEmpty()
 			outputs.file(debugFile)
-			onlyIf {
-				project.file("gradlew.bat").exists()
-			}
 			doLast {
 				debugFile.outputStream().use { out ->
 					val resourceName = "/gradled.bat"

--- a/plugin/base/src/test/kotlin/net/twisterrob/gradle/root/GradlePluginIntgTest.kt
+++ b/plugin/base/src/test/kotlin/net/twisterrob/gradle/root/GradlePluginIntgTest.kt
@@ -3,13 +3,12 @@ package net.twisterrob.gradle.root
 import net.twisterrob.gradle.BaseIntgTest
 import net.twisterrob.gradle.test.GradleRunnerRule
 import net.twisterrob.gradle.test.GradleRunnerRuleExtension
-import net.twisterrob.gradle.test.assertSkipped
+import net.twisterrob.gradle.test.assertNoSource
 import net.twisterrob.gradle.test.assertSuccess
 import net.twisterrob.gradle.test.assertUpToDate
 import net.twisterrob.gradle.test.root
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.not
-import org.hamcrest.assumeThat
 import org.hamcrest.io.FileMatchers.anExistingFile
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -24,7 +23,7 @@ class GradlePluginIntgTest : BaseIntgTest() {
 	override lateinit var gradle: GradleRunnerRule
 
 	@Test fun `skips debugWrapper if gradlew does not exist`() {
-		assumeThat(gradle.root.resolve("gradlew.bat"), not(anExistingFile()))
+		assertThat(gradle.root.resolve("gradlew.bat"), not(anExistingFile()))
 		@Language("gradle")
 		val script = """
 			plugins {
@@ -34,7 +33,7 @@ class GradlePluginIntgTest : BaseIntgTest() {
 
 		val result = gradle.run(script, "debugWrapper").build()
 
-		result.assertSkipped(":debugWrapper")
+		result.assertNoSource(":debugWrapper")
 	}
 
 	@Test fun `generates gradled if gradlew exists`() {
@@ -62,7 +61,7 @@ class GradlePluginIntgTest : BaseIntgTest() {
 		""".trimIndent()
 
 		gradle.run(script, "debugWrapper").build()
-		assumeThat(gradle.root.resolve("gradled.bat"), anExistingFile())
+		assertThat(gradle.root.resolve("gradled.bat"), anExistingFile())
 		val result = gradle.run(null, "debugWrapper").build()
 
 		result.assertUpToDate(":debugWrapper")

--- a/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
+++ b/plugin/base/src/testFixtures/kotlin/net/twisterrob/gradle/android/GradleTestHelpers.kt
@@ -1,6 +1,7 @@
 package net.twisterrob.gradle.android
 
 import com.android.ddmlib.AndroidDebugBridge
+import com.android.ddmlib.IDevice
 import com.jakewharton.dex.DexMethod
 import net.twisterrob.gradle.common.AGPVersions
 import net.twisterrob.test.process.assertOutput
@@ -214,7 +215,7 @@ fun dexMethod(className: String, methodName: String): Matcher<DexMethod> =
 			className == GradleTestHelpers.sourceName(item) && methodName == item.name
 	}
 
-fun hasDevices(): Boolean {
+fun devices(): List<IDevice> {
 	@Suppress("DEPRECATION") // REPORT Don't know why, cannot fix it.
 	AndroidDebugBridge.initIfNeeded(false)
 	val bridge = AndroidDebugBridge.createBridge(
@@ -227,7 +228,7 @@ fun hasDevices(): Boolean {
 	ensuredWait(5000L, 1000L, "Cannot get device list") {
 		bridge.hasInitialDeviceList()
 	}
-	return bridge.devices.isNotEmpty()
+	return bridge.devices.toList()
 }
 
 fun ensuredWait(initialWait: Long, reduceAmount: Long, message: String, block: () -> Boolean) {

--- a/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/kotlin-plugin_app/build.gradle
+++ b/plugin/base/src/testFixtures/resources/net/twisterrob/gradle/test/kotlin-plugin_app/build.gradle
@@ -10,7 +10,7 @@ if ("@net.twisterrob.test.kotlin.pluginVersion@" >= "1.8.20") {
 		}
 
 		def agp = "@net.twisterrob.test.android.pluginVersion@"
-		if (agp < "8.1.0" || ("8.1.0" < agp && agp < "8.1.0-alpha09")) {
+		if (agp < "8.1.0" || ("8.1.0" <= agp && agp < "8.1.0-alpha09")) {
 			// if above: Lexicographic version of equivalent semantic comparison: agp < 8.1.0-alpha09.
 			project.plugins.withType(com.android.build.gradle.internal.plugins.BasePlugin).configureEach {
 				android.compileOptions.sourceCompatibility = 11

--- a/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/tasks/CalculateVCSRevisionInfoTask.kt
+++ b/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/tasks/CalculateVCSRevisionInfoTask.kt
@@ -3,12 +3,20 @@ package net.twisterrob.gradle.android.tasks
 import net.twisterrob.gradle.android.addBuildConfigField
 import net.twisterrob.gradle.android.intermediateRegularFile
 import net.twisterrob.gradle.internal.safeWriteText
+import net.twisterrob.gradle.vcs.VCSExtension
 import net.twisterrob.gradle.vcs.VCSPluginExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByType
@@ -16,29 +24,41 @@ import org.gradle.kotlin.dsl.getByType
 @CacheableTask
 abstract class CalculateVCSRevisionInfoTask : DefaultTask() {
 
+	@get:InputFiles
+	@get:PathSensitive(PathSensitivity.RELATIVE)
+	abstract val trackingFiles: ConfigurableFileCollection
+
+	@get:Input
+	abstract val revision: Property<String>
+
+	@get:Input
+	abstract val revisionNumber: Property<Int>
+
 	@get:OutputFile
 	abstract val revisionFile: RegularFileProperty
 
 	@get:OutputFile
 	abstract val revisionNumberFile: RegularFileProperty
 
-	private val vcs: VCSPluginExtension
-		get() = project.extensions.getByType()
+	@get:Internal
+	internal abstract val vcs: Property<VCSExtension>
 
 	init {
-		// Delay input resolution to when the inputs are resolved for the task.
-		inputs.files(project.provider { vcs.current.files(project) })
-
-		@Suppress("LeakingThis")
-		revisionFile.convention(project.intermediateRegularFile("buildConfigDecorations/revision.txt"))
-		@Suppress("LeakingThis")
-		revisionNumberFile.convention(project.intermediateRegularFile("buildConfigDecorations/revisionNumber.txt"))
+		run { // === @Suppress("LeakingThis"), because .run { } is not detected.
+			vcs.convention(project.provider { project.extensions.getByType<VCSPluginExtension>().current })
+			// Delay input resolution to when the inputs are resolved for the task.
+			trackingFiles.setFrom(vcs.map { it.files(project) })
+			revision.convention(vcs.map(VCSExtension::revision))
+			revisionNumber.convention(vcs.map(VCSExtension::revisionNumber))
+			revisionFile.convention(project.intermediateRegularFile("buildConfigDecorations/revision.txt"))
+			revisionNumberFile.convention(project.intermediateRegularFile("buildConfigDecorations/revisionNumber.txt"))
+		}
 	}
 
 	@TaskAction
 	fun writeVCS() {
-		revisionFile.safeWriteText(vcs.current.revision)
-		revisionNumberFile.safeWriteText(vcs.current.revisionNumber.toString())
+		revisionFile.safeWriteText(revision.get())
+		revisionNumberFile.safeWriteText(revisionNumber.get().toString())
 	}
 
 	companion object {

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -114,11 +114,13 @@ class AndroidMinificationPlugin : BasePlugin() {
 		project.tasks.withType<LintModelWriterTask>().configureEach { it.mustRunAfter(task) }
 	}
 
-	private fun copy(internalName: String, targetFile: File) {
-		targetFile.parentFile.mkdirs()
-		val resource = this::class.java.getResourceAsStream(internalName)
-			?: error("Cannot find ${internalName} to copy to ${targetFile}.")
-		resource.use { inp -> targetFile.outputStream().use { out -> inp.copyTo(out) } }
-		targetFile.setLastModified(builtDate.toEpochMilli())
+	companion object {
+		private fun copy(internalName: String, targetFile: File) {
+			targetFile.parentFile.mkdirs()
+			val resource = AndroidMinificationPlugin::class.java.getResourceAsStream(internalName)
+				?: error("Cannot find ${internalName} to copy to ${targetFile}.")
+			resource.use { inp -> targetFile.outputStream().use { out -> inp.copyTo(out) } }
+			targetFile.setLastModified(builtDate.toEpochMilli())
+		}
 	}
 }

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
@@ -115,8 +115,8 @@ class AndroidReleasePlugin : BasePlugin() {
 			val defaultReleaseDir = layout.buildDirectory.dir("release")
 			val externalReleaseDir = providers.gradleProperty(RELEASE_PROPERTY)
 				.orElse(providers.environmentVariable(RELEASE_ENV).deprecated(logger))
-				.map(::file)
-			return layout.dir(externalReleaseDir).orElse(defaultReleaseDir)
+				.let { layout.projectDirectory.dir(it) }
+			return externalReleaseDir.orElse(defaultReleaseDir)
 		}
 
 		private fun <T : Any> Provider<T>.deprecated(logger: Logger): Provider<T> =

--- a/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
+++ b/plugin/release/src/test/kotlin/net/twisterrob/gradle/android/AndroidReleasePluginIntgTest.kt
@@ -96,6 +96,26 @@ class AndroidReleasePluginIntgTest : BaseAndroidIntgTest() {
 		result.assertDebugArchive(externalReleaseDir)
 	}
 
+	@Test fun `releases location can be set to a relative path (debug)`() {
+		@Language("gradle")
+		val script = """
+			plugins {
+				id("net.twisterrob.gradle.plugin.android-app")
+			}
+			android.defaultConfig.version { major = 1; minor = 2; patch = 3; build = 4 }
+		""".trimIndent()
+
+		@Language("properties")
+		val properties = """
+			net.twisterrob.android.release.directory=my/releases
+		""".trimIndent()
+		gradle.file(properties, ContentMergeMode.APPEND, "gradle.properties")
+
+		val result = gradle.run(script, "releaseDebug").build()
+
+		result.assertDebugArchive(File(gradle.root, "my/releases"))
+	}
+
 	@MethodSource("net.twisterrob.gradle.android.Minification#agpBasedParams")
 	@ParameterizedTest fun `releases the app to default location (release)`(
 		minification: Minification

--- a/plugin/reporting/src/main/kotlin/net/twisterrob/gradle/android/tasks/TestReportGenerator.kt
+++ b/plugin/reporting/src/main/kotlin/net/twisterrob/gradle/android/tasks/TestReportGenerator.kt
@@ -28,6 +28,7 @@ abstract class TestReportGenerator : DefaultTask() {
 	abstract val type: Property<ReportType>
 
 	init {
+		@Suppress("LeakingThis")
 		type.convention(ReportType.SINGLE_FLAVOR)
 	}
 

--- a/plugin/reporting/src/main/kotlin/net/twisterrob/gradle/android/tasks/TestReportGenerator.kt
+++ b/plugin/reporting/src/main/kotlin/net/twisterrob/gradle/android/tasks/TestReportGenerator.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.internal.test.report.ResilientTestReport
 import com.android.utils.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -23,16 +24,21 @@ abstract class TestReportGenerator : DefaultTask() {
 	@get:OutputDirectory
 	abstract val output: DirectoryProperty
 
-	@Input
-	var type: ReportType = ReportType.SINGLE_FLAVOR
+	@get:Input
+	abstract val type: Property<ReportType>
+
+	init {
+		type.convention(ReportType.SINGLE_FLAVOR)
+	}
 
 	@TaskAction
 	fun generate() {
-		val inp = input.get().asFile
-		val out = output.get().asFile
+		val input = this.input.get().asFile
+		val output = this.output.get().asFile
+		val type = this.type.get()
 
-		FileUtils.cleanOutputDir(out)
-		val report = ResilientTestReport(type, inp, out)
+		FileUtils.cleanOutputDir(output)
+		val report = ResilientTestReport(type, input, output)
 
 		report.generateReport()
 	}

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
@@ -21,23 +21,23 @@ class GITPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)
-		project.vcs.extensions.create<GITPluginExtension>(GITPluginExtension.NAME, project)
+		project.vcs.extensions.create<GITPluginExtension>(GITPluginExtension.NAME, project.rootDir)
 	}
 }
 
 open class GITPluginExtension(
-	private val project: Project
+	private val rootDir: File
 ) : VCSExtension {
 
 	override val isAvailableQuick: Boolean
-		get() = project.rootDir.resolve(".git").exists()
+		get() = rootDir.resolve(".git").exists()
 
 	// 'git describe --always'.execute([], project.rootDir).waitFor() == 0
 	override val isAvailable: Boolean
 		get() {
 			// Check more than just the presence of .git to lessen the possibility of detecting "git",
 			// but not actually having a git repository.
-			RepositoryCache.FileKey.resolve(project.rootDir, FS.DETECTED) ?: return false
+			RepositoryCache.FileKey.resolve(rootDir, FS.DETECTED) ?: return false
 			return try {
 				// Actually try to open the repository now.
 				inRepo { /* Just open, then close. */ }
@@ -88,7 +88,7 @@ open class GITPluginExtension(
 		)
 
 	private inline fun <T> inRepo(block: Git.() -> T): T =
-		inRepo(project.rootDir, block)
+		inRepo(rootDir, block)
 
 	companion object {
 

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/FileCountReportTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/FileCountReportTask.kt
@@ -15,6 +15,7 @@ abstract class FileCountReportTask : BaseViolationsTask() {
 	abstract val output: RegularFileProperty
 
 	init {
+		@Suppress("LeakingThis")
 		output.convention(project.reporting.baseDirectory.file("violations.count"))
 	}
 

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalLintGlobalFinalizerTask.kt
@@ -20,7 +20,9 @@ import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -43,6 +45,24 @@ abstract class GlobalLintGlobalFinalizerTask : DefaultTask() {
 	@get:PathSensitive(PathSensitivity.NONE)
 	abstract val xmlReports: ListProperty<RegularFile>
 
+	@get:Internal
+	internal abstract val hasConsole: Property<Boolean>
+
+	@get:Internal
+	internal abstract val hasHtml: Property<Boolean>
+
+	@get:Internal
+	internal abstract val wasExplicitLaunch: Property<Boolean>
+
+	init {
+		@Suppress("LeakingThis")
+		hasConsole.convention(project.provider { project.gradle.taskGraph.hasTask(":$REPORT_CONSOLE_TASK_NAME") })
+		@Suppress("LeakingThis")
+		hasHtml.convention(project.provider { project.gradle.taskGraph.hasTask(":$$REPORT_HTML_TASK_NAME") })
+		@Suppress("LeakingThis")
+		wasExplicitLaunch.convention(project.provider { this.wasLaunchedExplicitly })
+	}
+
 	@TaskAction
 	fun failOnFailures() {
 		val gatherer = LintReportGatherer()
@@ -53,8 +73,6 @@ abstract class GlobalLintGlobalFinalizerTask : DefaultTask() {
 			.associateBy({ it }) { gatherer.findViolations(it) }
 		val totalCount = violationsByFile.values.sumBy { violations: List<Violation> -> violations.size }
 		if (totalCount > 0) {
-			val hasConsole = project.gradle.taskGraph.hasTask(":$REPORT_CONSOLE_TASK_NAME")
-			val hasHtml = project.gradle.taskGraph.hasTask(":$REPORT_HTML_TASK_NAME")
 			val projectReports = violationsByFile.entries
 				.map { (report, violations) ->
 					"${report} (${violations.size})"
@@ -64,14 +82,14 @@ abstract class GlobalLintGlobalFinalizerTask : DefaultTask() {
 				"Ran lint on subprojects: ${totalCount} issues found.",
 				"See reports in subprojects:",
 				*projectReports.toTypedArray(),
-				if (hasConsole || hasHtml) {
+				if (hasConsole.get() || hasHtml.get()) {
 					null // No message, it's already going to execute.
 				} else {
 					"To get a full breakdown and listing, execute $REPORT_CONSOLE_TASK_NAME or $REPORT_HTML_TASK_NAME."
 				}
 			)
 			val message = lines.joinToString(separator = System.lineSeparator())
-			if (this.wasLaunchedExplicitly) {
+			if (wasExplicitLaunch.get()) {
 				throw GradleException(message)
 			} else {
 				logger.warn(message)

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/HtmlReportTask.kt
@@ -54,9 +54,13 @@ abstract class HtmlReportTask : BaseViolationsTask() {
 		get() = xsl.asFile.get()
 
 	init {
+		@Suppress("LeakingThis")
 		xml.convention(project.reporting.baseDirectory.file("violations.xml"))
+		@Suppress("LeakingThis")
 		html.convention(project.reporting.baseDirectory.file("violations.html"))
+		@Suppress("LeakingThis")
 		val xslName: Provider<String> = xslTemplate.map { it.asFile.name }.orElse("violations.xsl")
+		@Suppress("LeakingThis")
 		xsl.convention(project.layout.file(xml.zip(xslName) { xml, xslFileName ->
 			xml.asFile.parentFile.resolve(xslFileName)
 		}))

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
@@ -1,9 +1,12 @@
 package net.twisterrob.gradle.quality.tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.plugins.quality.PmdExtension
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 
@@ -11,21 +14,33 @@ import org.gradle.api.tasks.UntrackedTask
 @UntrackedTask(because = "It is used to inspect Gradle state, output is console.")
 abstract class VersionsTask : DefaultTask() {
 
+	@get:Input
+	internal abstract val gradleVersion: Property<String>
+
+	@get:Input
+	internal abstract val checkstyleVersion: Property<String>
+
+	@get:Input
+	internal abstract val pmdVersion: Property<String>
+
 	init {
 		outputs.upToDateWhen { false }
+		gradleVersion.convention(project.provider { project.gradle.gradleVersion })
+		checkstyleVersion.convention(project.provider { project.getVersion<CheckstyleExtension>("checkstyle") })
+		pmdVersion.convention(project.provider { project.getVersion<PmdExtension>("pmd") })
 	}
 
 	@TaskAction
 	fun printVersions() {
 		logger.quiet(
 			"""
-				Gradle version: ${project.gradle.gradleVersion}
-				Checkstyle version: ${getVersion("checkstyle", CheckstyleExtension::class.java)}
-				PMD version: ${getVersion("pmd", PmdExtension::class.java)}
+				Gradle version: ${gradleVersion.get()}
+				Checkstyle version: ${checkstyleVersion.get()}
+				PMD version: ${pmdVersion.get()}
 			""".trimIndent()
 		)
 	}
-
-	private fun getVersion(pluginName: String, type: Class<out CodeQualityExtension>): String =
-		project.extensions.findByType(type)?.toolVersion ?: "'${pluginName}' plugin not applied"
 }
+
+private inline fun <reified T : CodeQualityExtension> Project.getVersion(pluginName: String): String =
+	project.extensions.findByType(T::class.java)?.toolVersion ?: "'${pluginName}' plugin not applied"

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
@@ -24,8 +24,11 @@ abstract class VersionsTask : DefaultTask() {
 	internal abstract val pmdVersion: Property<String>
 
 	init {
+		@Suppress("LeakingThis")
 		gradleVersion.convention(project.provider { project.gradle.gradleVersion })
+		@Suppress("LeakingThis")
 		checkstyleVersion.convention(project.provider { project.getVersion<CheckstyleExtension>("checkstyle") })
+		@Suppress("LeakingThis")
 		pmdVersion.convention(project.provider { project.getVersion<PmdExtension>("pmd") })
 	}
 

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTask.kt
@@ -24,7 +24,6 @@ abstract class VersionsTask : DefaultTask() {
 	internal abstract val pmdVersion: Property<String>
 
 	init {
-		outputs.upToDateWhen { false }
 		gradleVersion.convention(project.provider { project.gradle.gradleVersion })
 		checkstyleVersion.convention(project.provider { project.getVersion<CheckstyleExtension>("checkstyle") })
 		pmdVersion.convention(project.provider { project.getVersion<PmdExtension>("pmd") })

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTaskTest.kt
@@ -180,8 +180,10 @@ class GlobalTestFinalizerTaskTest : BaseIntgTest() {
 		}
 
 		assertThat(
-			result.taskPaths(TaskOutcome.FAILED),
-			either(contains(":testDebugUnitTest")).or(contains(":testReleaseUnitTest"))
+			result.taskPaths(TaskOutcome.FAILED), // Parallel execution can cause any combination of failures.
+			either(contains(":testDebugUnitTest", ":testReleaseUnitTest"))
+				.or(contains(":testDebugUnitTest"))
+				.or(contains(":testReleaseUnitTest"))
 		)
 		result.assertNoTask(":testReport")
 		result.assertHasOutputLine(Regex("""> There were failing tests. See the report at: .*"""))

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
@@ -38,6 +38,21 @@ class VersionsTaskTest : BaseIntgTest() {
 		result.assertHasOutputLine("""PMD version: 'pmd' plugin not applied""")
 	}
 
+	@Test fun `task is never up to date`() {
+		@Language("gradle")
+		val script = """
+			plugins {
+				id("net.twisterrob.gradle.plugin.quality") apply false
+			}
+			tasks.register('qualityVersions', ${VersionsTask::class.java.name})
+		""".trimIndent()
+		gradle.file(script, gradle.buildFile.name)
+
+		gradle.run(null, "qualityVersions").build().assertSuccess(":qualityVersions")
+		gradle.run(null, "qualityVersions").build().assertSuccess(":qualityVersions")
+		gradle.run(null, "qualityVersions").build().assertSuccess(":qualityVersions")
+	}
+
 	@Test fun `print versions when plugins applied late`() {
 		@Language("gradle")
 		val script = """

--- a/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
+++ b/quality/src/test/kotlin/net/twisterrob/gradle/quality/tasks/VersionsTaskTest.kt
@@ -38,6 +38,29 @@ class VersionsTaskTest : BaseIntgTest() {
 		result.assertHasOutputLine("""PMD version: 'pmd' plugin not applied""")
 	}
 
+	@Test fun `print versions when plugins applied late`() {
+		@Language("gradle")
+		val script = """
+			plugins {
+				id("net.twisterrob.gradle.plugin.quality") apply false
+			}
+			tasks.create('qualityVersions', ${VersionsTask::class.java.name}) // Intentionally eagerly creating.
+			afterEvaluate {
+				apply plugin: "org.gradle.checkstyle"
+				apply plugin: "org.gradle.pmd"
+			}
+		""".trimIndent()
+
+		val result = gradle.runBuild {
+			run(script, "qualityVersions")
+		}
+
+		result.assertSuccess(":qualityVersions")
+		result.assertHasOutputLine(Regex("""Gradle version: .+"""))
+		result.assertHasOutputLine(Regex("""Checkstyle version: \d+(\.\d+)+"""))
+		result.assertHasOutputLine(Regex("""PMD version: \d+(\.\d+)+"""))
+	}
+
 	@Test fun `print checkstyle version (Gradle 7 latest)`() {
 		gradle.gradleVersion = GradleVersion.version("7.6.1")
 

--- a/test/src/main/resources/net/twisterrob/gradle/test/runtime.init.gradle.kts
+++ b/test/src/main/resources/net/twisterrob/gradle/test/runtime.init.gradle.kts
@@ -41,10 +41,21 @@ rootProject {
 	)
 }
 
-// TODO deprecated without replacement https://github.com/gradle/gradle/issues/20151
-// Best effort for now as it won't work with configuration cache.
-@Suppress("DEPRECATION")
-gradle.buildFinished { println(memoryDiagnostics()) }
+if (!gradle.startParameter.isConfigurationCacheRequested) {
+	// TODO deprecated without replacement https://github.com/gradle/gradle/issues/20151
+	// Best effort for now as it won't work with configuration cache.
+	@Suppress("DEPRECATION")
+	gradle.buildFinished { println(memoryDiagnostics()) }
+} else {
+	// This might be a future solution, but for now this init script is used with Gradle 7.x too,
+	// which doesn't have this flow API, only Gradle 8.1+ does.
+	// class PrintDiagnostics : FlowAction<FlowParameters.None> {
+	// 	override fun execute(ignore: FlowParameters.None) {
+	// 		println(memoryDiagnostics())
+	// 	}
+	// }
+	// serviceOf<FlowScope>().always(PrintDiagnostics::class.java) { }
+}
 
 fun memoryDiagnostics(): String {
 	fun format(max: Long?, used:Long): String {

--- a/test/src/test/kotlin/net/twisterrob/gradle/test/TestPluginTest.kt
+++ b/test/src/test/kotlin/net/twisterrob/gradle/test/TestPluginTest.kt
@@ -86,9 +86,10 @@ class TestPluginTest : BaseIntgTest() {
 			dependencies {
 				testImplementation 'junit:junit:${Version.id()}'
 			}
-			// output test execution result so we can verify it actually ran
+			// Output test execution result, so we can verify it actually ran.
+			// This doesn't work with configuration cache: https://github.com/gradle/gradle/issues/25311
 			test.afterTest { desc, result ->
-				logger.quiet "${'$'}{desc.className} > ${'$'}{desc.name}: ${'$'}{result.resultType}"
+				logger.quiet("${'$'}{desc.className} > ${'$'}{desc.name}: ${'$'}{result.resultType}")
 			}
 		""".trimIndent()
 


### PR DESCRIPTION
Fixes #155

Method:
```patch
Subject: [PATCH] Investigate CC
---
Index: gradle.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/gradle.properties b/gradle.properties
--- a/gradle.properties	(revision 6d10a7558c1a7a0f0dd6032596c65f321fe02bbd)
+++ b/gradle.properties	(date 1686063191858)
@@ -33,7 +33,7 @@
 # AGP: 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.2, 8.0.2, 8.1.0
 net.twisterrob.test.android.pluginVersion=8.1.0-beta04
 # Kotlin: AGP 7.0.4-7.2.2 -> Kotlin 1.4.32; AGP 7.3.0- -> Kotlin 1.6.21
-net.twisterrob.test.kotlin.pluginVersion=1.6.21
+net.twisterrob.test.kotlin.pluginVersion=1.8.21
 # Gradle: 7.0.2, 7.2, 7.3.3, 7.4.2, 7.5.1, 7.6.1, 8.0.2, 8.1
 net.twisterrob.gradle.runner.gradleVersion=8.2-rc-1
 # Java: AGP 7.0.0-7.4.2 -> Java 11; AGP 8.0.0-∞ -> Java 17
Index: test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt b/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
--- a/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt	(revision 6d10a7558c1a7a0f0dd6032596c65f321fe02bbd)
+++ b/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt	(date 1686043011083)
@@ -15,6 +15,7 @@
 			get() = super.extraArgs + arrayOf(
 				// https://docs.gradle.org/5.6/release-notes.html#fail-the-build-on-deprecation-warnings
 				"--warning-mode=fail",
+				"--configuration-cache", "--configuration-cache-problems=fail",
 				"--init-script=runtime.init.gradle.kts",
 				"--init-script=nagging.init.gradle.kts",
 			)
```
then `gradlew test testReport --continue`

This gave some actionable warnings/failures which are fixed in this PR, whatever was too complex to fix now were moved to #306