### PR TITLE
Renovate: Fix Gradle upgrades leaking into AGP upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -120,7 +120,7 @@
 			"registryUrlTemplate": "https://maven.google.com",
 			"depNameTemplate": "com.android.tools.build:gradle",
 			"matchStrings": [
-				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
+				"AGP (.*?) on Gradle (.*?)( - plugin)? \\((.*?) on (.*?)\\) Test Results (XMLs|HTMLs|HTML)",
 				"\\(.*?\\)",
 				"\\((?<currentValue>.*) on "
 			],
@@ -165,7 +165,7 @@
 			"datasourceTemplate": "gradle-version",
 			"depNameTemplate": "gradle",
 			"matchStrings": [
-				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
+				"AGP (.*?) on Gradle (.*?)( - plugin)? \\((.*?) on (.*?)\\) Test Results (XMLs|HTMLs|HTML)",
 				"\\(.*?\\)",
 				" on (?<currentValue>.*)\\)"
 			],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -103,15 +103,26 @@
 	],
 	"regexManagers": [
 		{
-			"description": "Update AGP compatibility CI matrix values and artifact names.",
+			"description": "Update AGP compatibility CI matrix values.",
 			"fileMatch": ["^\\.github/workflows/CI\\.yml$"],
 			"datasourceTemplate": "maven",
 			"registryUrlTemplate": "https://maven.google.com",
 			"depNameTemplate": "com.android.tools.build:gradle",
 			"matchStrings": [
-				"  agp: '(?<currentValue>.*)'",
-				"AGP (?:.*) on Gradle (?:.*)(?: - plugin)? \\((?<currentValue>.*) on (?:.*)\\) Test Results (?:XMLs|HTMLs|HTML)"
+				"  agp: '(?<currentValue>.*)'"
 			],
+			"versioningTemplate": "gradle"
+		},
+		{
+			"description": "Update AGP compatibility CI artifact names.",
+			"fileMatch": ["^\\.github/workflows/CI\\.yml$"],
+			"datasourceTemplate": "maven",
+			"registryUrlTemplate": "https://maven.google.com",
+			"depNameTemplate": "com.android.tools.build:gradle",
+			"matchStrings": [
+				"AGP (?<agpName>.*?) on Gradle (?<gradleName>.*?)(?<plugin> - plugin)? \\((?<currentValue>.*?) on (?<gradleExact>.*?)\\) Test Results (?<artifactType>XMLs|HTMLs|HTML)"
+			],
+			"autoReplaceStringTemplate": "AGP {{{agpName}}} on Gradle {{{gradleName}}}{{{plugin}}} ({{{newValue}}} on {{{gradleExact}}}) Test Results {{{artifactType}}}",
 			"versioningTemplate": "gradle"
 		},
 		{
@@ -137,14 +148,24 @@
 			"versioningTemplate": "gradle"
 		},
 		{
-			"description": "Update Gradle compatibility CI matrix values and artifact names.",
+			"description": "Update Gradle compatibility CI matrix values.",
 			"fileMatch": ["^\\.github/workflows/CI\\.yml$"],
 			"datasourceTemplate": "gradle-version",
 			"depNameTemplate": "gradle",
 			"matchStrings": [
-				"  gradle: '(?<currentValue>.*)'",
-				"AGP (?:.*) on Gradle (?:.*)(?: - plugin)? \\((?:.*) on (?<currentValue>.*)\\) Test Results (?:XMLs|HTMLs|HTML)"
+				"  gradle: '(?<currentValue>.*)'"
 			],
+			"versioningTemplate": "gradle"
+		},
+		{
+			"description": "Update Gradle compatibility CI artifact names.",
+			"fileMatch": ["^\\.github/workflows/CI\\.yml$"],
+			"datasourceTemplate": "gradle-version",
+			"depNameTemplate": "gradle",
+			"matchStrings": [
+				"AGP (?<agpName>.*?) on Gradle (?<gradleName>.*?)(?<plugin> - plugin)? \\((?<agpExact>.*?) on (?<currentValue>.*?)\\) Test Results (?<artifactType>XMLs|HTMLs|HTML)"
+			],
+			"autoReplaceStringTemplate": "AGP {{{agpName}}} on Gradle {{{gradleName}}}{{{plugin}}} ({{{agpExact}}} on {{{newValue}}}) Test Results {{{artifactType}}}",
 			"versioningTemplate": "gradle"
 		},
 		{

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -120,9 +120,11 @@
 			"registryUrlTemplate": "https://maven.google.com",
 			"depNameTemplate": "com.android.tools.build:gradle",
 			"matchStrings": [
-				"AGP (?<agpName>.*?) on Gradle (?<gradleName>.*?)(?<plugin> - plugin)? \\((?<currentValue>.*?) on (?<gradleExact>.*?)\\) Test Results (?<artifactType>XMLs|HTMLs|HTML)"
+				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
+				"(?<=\\().*?(?=\\))",
+				"(?<currentValue>.*) on "
 			],
-			"autoReplaceStringTemplate": "AGP {{{agpName}}} on Gradle {{{gradleName}}}{{{plugin}}} ({{{newValue}}} on {{{gradleExact}}}) Test Results {{{artifactType}}}",
+			"matchStringsStrategy": "recursive",
 			"versioningTemplate": "gradle"
 		},
 		{
@@ -163,9 +165,11 @@
 			"datasourceTemplate": "gradle-version",
 			"depNameTemplate": "gradle",
 			"matchStrings": [
-				"AGP (?<agpName>.*?) on Gradle (?<gradleName>.*?)(?<plugin> - plugin)? \\((?<agpExact>.*?) on (?<currentValue>.*?)\\) Test Results (?<artifactType>XMLs|HTMLs|HTML)"
+				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
+				"(?<=\\().*?(?=\\))",
+				" on (?<currentValue>.*)"
 			],
-			"autoReplaceStringTemplate": "AGP {{{agpName}}} on Gradle {{{gradleName}}}{{{plugin}}} ({{{agpExact}}} on {{{newValue}}}) Test Results {{{artifactType}}}",
+			"matchStringsStrategy": "recursive",
 			"versioningTemplate": "gradle"
 		},
 		{

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -121,8 +121,8 @@
 			"depNameTemplate": "com.android.tools.build:gradle",
 			"matchStrings": [
 				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
-				"(?<=\\().*?(?=\\))",
-				"(?<currentValue>.*) on "
+				"\\(.*?\\)",
+				"\\((?<currentValue>.*) on "
 			],
 			"matchStringsStrategy": "recursive",
 			"versioningTemplate": "gradle"
@@ -166,8 +166,8 @@
 			"depNameTemplate": "gradle",
 			"matchStrings": [
 				"AGP .*? on Gradle ( - plugin)? \\(.*? on .*?\\) Test Results (XMLs|HTMLs|HTML)",
-				"(?<=\\().*?(?=\\))",
-				" on (?<currentValue>.*)"
+				"\\(.*?\\)",
+				" on (?<currentValue>.*)\\)"
 			],
 			"matchStringsStrategy": "recursive",
 			"versioningTemplate": "gradle"


### PR DESCRIPTION
Based on options in https://github.com/renovatebot/renovate/discussions/23288
 * autoReplaceStringTemplate -> error (probably a bug)
 * lookaround -> error (forbidden)
 * matchStringStrategy -> works, good enough