### PR TITLE
Make all Gradle created classes abstract

### DIFF
--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleExtension.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleExtension.kt
@@ -2,4 +2,5 @@ package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.common.BaseQualityExtension
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class CheckStyleExtension : BaseQualityExtension<CheckStyleTask>()

--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleExtension.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleExtension.kt
@@ -2,4 +2,4 @@ package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.common.BaseQualityExtension
 
-open class CheckStyleExtension : BaseQualityExtension<CheckStyleTask>()
+abstract class CheckStyleExtension : BaseQualityExtension<CheckStyleTask>()

--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePlugin.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePlugin.kt
@@ -2,7 +2,7 @@ package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.common.BaseQualityPlugin
 
-class CheckStylePlugin : BaseQualityPlugin(
+abstract class CheckStylePlugin : BaseQualityPlugin(
 	CheckStyleTaskCreator::class.java,
 	"checkstyle",
 	CheckStyleExtension::class.java

--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePlugin.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStylePlugin.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.checkstyle
 
 import net.twisterrob.gradle.common.BaseQualityPlugin
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class CheckStylePlugin : BaseQualityPlugin(
 	CheckStyleTaskCreator::class.java,
 	"checkstyle",

--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTask.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTask.kt
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 
 @CacheableTask
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class CheckStyleTask : Checkstyle(), TargetChecker {
 
 	@Input

--- a/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTask.kt
+++ b/checkers/checkstyle/src/main/kotlin/net/twisterrob/gradle/checkstyle/CheckStyleTask.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 
 @CacheableTask
-open class CheckStyleTask : Checkstyle(), TargetChecker {
+abstract class CheckStyleTask : Checkstyle(), TargetChecker {
 
 	@Input
 	override var checkTargetName: String = ALL_VARIANTS_NAME

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdExtension.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdExtension.kt
@@ -2,4 +2,5 @@ package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.common.BaseQualityExtension
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class PmdExtension : BaseQualityExtension<PmdTask>()

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdExtension.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdExtension.kt
@@ -2,4 +2,4 @@ package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.common.BaseQualityExtension
 
-open class PmdExtension : BaseQualityExtension<PmdTask>()
+abstract class PmdExtension : BaseQualityExtension<PmdTask>()

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdPlugin.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdPlugin.kt
@@ -2,6 +2,7 @@ package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.common.BaseQualityPlugin
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class PmdPlugin : BaseQualityPlugin(
 	PmdTaskCreator::class.java,
 	"pmd",

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdPlugin.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdPlugin.kt
@@ -2,7 +2,7 @@ package net.twisterrob.gradle.pmd
 
 import net.twisterrob.gradle.common.BaseQualityPlugin
 
-class PmdPlugin : BaseQualityPlugin(
+abstract class PmdPlugin : BaseQualityPlugin(
 	PmdTaskCreator::class.java,
 	"pmd",
 	PmdExtension::class.java

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdTask.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdTask.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 
 @CacheableTask
-open class PmdTask : Pmd(), TargetChecker {
+abstract class PmdTask : Pmd(), TargetChecker {
 
 	@Input
 	override var checkTargetName: String = ALL_VARIANTS_NAME

--- a/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdTask.kt
+++ b/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdTask.kt
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 
 @CacheableTask
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class PmdTask : Pmd(), TargetChecker {
 
 	@Input

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseExposedPlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseExposedPlugin.kt
@@ -1,3 +1,3 @@
 package net.twisterrob.gradle.common
 
-open class BaseExposedPlugin : BasePlugin()
+abstract class BaseExposedPlugin : BasePlugin()

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseExposedPlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseExposedPlugin.kt
@@ -1,3 +1,4 @@
 package net.twisterrob.gradle.common
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class BaseExposedPlugin : BasePlugin()

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 
-open class BasePlugin : Plugin<Project> {
+abstract class BasePlugin : Plugin<Project> {
 
 	@Suppress(
 		"PropertyName", // Keep it consistent with external loggers.

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BasePlugin.kt
@@ -9,6 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class BasePlugin : Plugin<Project> {
 
 	@Suppress(

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityExtension.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityExtension.kt
@@ -5,7 +5,7 @@ import org.gradle.api.internal.file.pattern.PatternMatcherFactory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.util.PatternSet
 
-open class BaseQualityExtension<T>(
+abstract class BaseQualityExtension<T>(
 	internal var taskConfigurator: Action<TaskConfigurator<T>> = Action {}
 ) where T : SourceTask {
 

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityExtension.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.internal.file.pattern.PatternMatcherFactory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.util.PatternSet
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class BaseQualityExtension<T>(
 	internal var taskConfigurator: Action<TaskConfigurator<T>> = Action {}
 ) where T : SourceTask {

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityPlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityPlugin.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceTask
 
-open class BaseQualityPlugin(
+abstract class BaseQualityPlugin(
 	private val taskCreatorType: Class<out VariantTaskCreator<*>>,
 	private val extensionName: String,
 	private val extensionType: Class<out BaseQualityExtension<out SourceTask>>
@@ -29,4 +29,4 @@ open class BaseQualityPlugin(
 private inline fun <T, reified P1> Class<T>.newInstance(p1: P1?): T =
 	this.getDeclaredConstructor(P1::class.java).newInstance(p1)
 
-private open class FakeQualityExtension
+private abstract class FakeQualityExtension

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityPlugin.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/BaseQualityPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceTask
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class BaseQualityPlugin(
 	private val taskCreatorType: Class<out VariantTaskCreator<*>>,
 	private val extensionName: String,
@@ -29,4 +30,5 @@ abstract class BaseQualityPlugin(
 private inline fun <T, reified P1> Class<T>.newInstance(p1: P1?): T =
 	this.getDeclaredConstructor(P1::class.java).newInstance(p1)
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 private abstract class FakeQualityExtension

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/VariantTaskCreator.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/VariantTaskCreator.kt
@@ -21,7 +21,7 @@ import java.io.File
 @Suppress("DEPRECATION" /* AGP 7.0 */)
 private typealias BaseVariant = com.android.build.gradle.api.BaseVariant
 
-open class VariantTaskCreator<T>(
+abstract class VariantTaskCreator<T>(
 	private val project: Project,
 	private val baseName: String,
 	private val pluginName: String,

--- a/common/src/main/kotlin/net/twisterrob/gradle/common/VariantTaskCreator.kt
+++ b/common/src/main/kotlin/net/twisterrob/gradle/common/VariantTaskCreator.kt
@@ -21,7 +21,7 @@ import java.io.File
 @Suppress("DEPRECATION" /* AGP 7.0 */)
 private typealias BaseVariant = com.android.build.gradle.api.BaseVariant
 
-abstract class VariantTaskCreator<T>(
+open class VariantTaskCreator<T>(
 	private val project: Project,
 	private val baseName: String,
 	private val pluginName: String,

--- a/compat/gradle/src/main/kotlin/net/twisterrob/gradle/internal/deprecation/DeprecatedPlugin.kt
+++ b/compat/gradle/src/main/kotlin/net/twisterrob/gradle/internal/deprecation/DeprecatedPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.deprecation.DeprecationMessageBuilder
 import org.gradle.util.GradleVersion
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class DeprecatedProjectPlugin(
 	private val oldName: String,
 	private val newName: String,
@@ -20,6 +21,7 @@ abstract class DeprecatedProjectPlugin(
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class DeprecatedSettingsPlugin(
 	private val oldName: String,
 	private val newName: String,

--- a/compat/gradle/src/main/kotlin/net/twisterrob/gradle/internal/deprecation/DeprecatedPlugin.kt
+++ b/compat/gradle/src/main/kotlin/net/twisterrob/gradle/internal/deprecation/DeprecatedPlugin.kt
@@ -9,7 +9,7 @@ import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.deprecation.DeprecationMessageBuilder
 import org.gradle.util.GradleVersion
 
-open class DeprecatedProjectPlugin(
+abstract class DeprecatedProjectPlugin(
 	private val oldName: String,
 	private val newName: String,
 ) : Plugin<Project> {
@@ -20,7 +20,7 @@ open class DeprecatedProjectPlugin(
 	}
 }
 
-open class DeprecatedSettingsPlugin(
+abstract class DeprecatedSettingsPlugin(
 	private val oldName: String,
 	private val newName: String,
 ) : Plugin<Settings> {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/compilation/JavaCompatibilityPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/compilation/JavaCompatibilityPlugin.kt
@@ -3,6 +3,7 @@ package net.twisterrob.gradle.build.compilation
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class JavaCompatibilityPlugin : Plugin<Project> {
 	override fun apply(target: Project) {
 		target.dependencies.components {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/compilation/JavaCompatibilityPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/compilation/JavaCompatibilityPlugin.kt
@@ -3,7 +3,7 @@ package net.twisterrob.gradle.build.compilation
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-class JavaCompatibilityPlugin : Plugin<Project> {
+abstract class JavaCompatibilityPlugin : Plugin<Project> {
 	override fun apply(target: Project) {
 		target.dependencies.components {
 			// AGP 8.0.0-alpha10 requires Java 17 (https://issuetracker.google.com/issues/241546506)

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/deprecation/DeprecatedPluginKotlinGeneratingTask.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/deprecation/DeprecatedPluginKotlinGeneratingTask.kt
@@ -31,12 +31,14 @@ internal abstract class DeprecatedPluginKotlinGeneratingTask : DefaultTask() {
 		val packageName = implementationClass.substringBeforeLast('.')
 		val className = implementationClass.substringAfterLast('.')
 		@Language("kotlin")
+		@Suppress("ClassName")
 		val deprecatedPluginSourceCode = """
 			package ${packageName}
 			
 			import net.twisterrob.gradle.internal.deprecation.DeprecatedProjectPlugin
 			
-			internal class ${className}Deprecated : DeprecatedProjectPlugin(
+			@Suppress("UnnecessaryAbstractClass") // Gradle convention.
+			internal abstract class ${className}Deprecated : DeprecatedProjectPlugin(
 				oldName = "${oldName.get()}",
 				newName = "${newName.get()}",
 			)

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 internal abstract class DetektPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektPlugin.kt
@@ -9,7 +9,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
 
-internal class DetektPlugin : Plugin<Project> {
+internal abstract class DetektPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {
 		project.plugins.apply("io.gitlab.arturbosch.detekt")

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektRootPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektRootPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 internal abstract class DetektRootPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektRootPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/detekt/DetektRootPlugin.kt
@@ -14,7 +14,7 @@ import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
-internal class DetektRootPlugin : Plugin<Project> {
+internal abstract class DetektRootPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {
 		require(project.subprojects.isNotEmpty()) {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/GradlePluginValidationPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/GradlePluginValidationPlugin.kt
@@ -10,6 +10,7 @@ import org.gradle.plugin.devel.PluginDeclaration
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 import org.gradle.plugin.devel.tasks.ValidatePlugins
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GradlePluginValidationPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/GradlePluginValidationPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/GradlePluginValidationPlugin.kt
@@ -10,7 +10,7 @@ import org.gradle.plugin.devel.PluginDeclaration
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 import org.gradle.plugin.devel.tasks.ValidatePlugins
 
-class GradlePluginValidationPlugin : Plugin<Project> {
+abstract class GradlePluginValidationPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {
 		project.plugins.withId("org.gradle.java-gradle-plugin") {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptMetadataPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptMetadataPlugin.kt
@@ -20,7 +20,7 @@ import org.gradle.kotlin.dsl.register
 /**
  * @see org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
  */
-class InitScriptMetadataPlugin : Plugin<Project> {
+abstract class InitScriptMetadataPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {
 		val initScriptConfiguration = project.createClasspath()

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptMetadataPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/InitScriptMetadataPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.kotlin.dsl.register
 /**
  * @see org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
  */
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class InitScriptMetadataPlugin : Plugin<Project> {
 
 	override fun apply(project: Project) {

--- a/graph/buildSrc/src/main/kotlin/net/twisterrob/gradle/webjars/ExtractWebJarsExtension.kt
+++ b/graph/buildSrc/src/main/kotlin/net/twisterrob/gradle/webjars/ExtractWebJarsExtension.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.named
 
-open class ExtractWebJarsExtension(
+abstract class ExtractWebJarsExtension(
 	private val project: Project,
 ) {
 	fun extractInto(target: SourceDirectorySet) {

--- a/graph/src/main/kotlin/net/twisterrob/gradle/graph/GraphPlugin.kt
+++ b/graph/src/main/kotlin/net/twisterrob/gradle/graph/GraphPlugin.kt
@@ -116,7 +116,7 @@ class GraphPlugin @Inject constructor(
 	}
 }
 
-@Suppress("UnnecessaryAbstractClass") // Gradle extensions must be abstract.
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GraphSettingsExtension {
 
 	var isKeepOpen: Boolean = false

--- a/graph/src/main/kotlin/net/twisterrob/gradle/graph/GraphPlugin.kt
+++ b/graph/src/main/kotlin/net/twisterrob/gradle/graph/GraphPlugin.kt
@@ -20,7 +20,8 @@ import javax.inject.Inject
 
 private val LOG = logger<GraphPlugin>()
 
-class GraphPlugin @Inject constructor(
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
+abstract class GraphPlugin @Inject constructor(
 	private val cacheRepository: ScopedCacheBuilderFactory,
 ) : Plugin<Settings> {
 

--- a/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
+++ b/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Task
 import org.gradle.kotlin.dsl.register
 import org.gradle.util.GradleVersion
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GradlePlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
+++ b/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/GradlePlugin.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Task
 import org.gradle.kotlin.dsl.register
 import org.gradle.util.GradleVersion
 
-class GradlePlugin : BasePlugin() {
+abstract class GradlePlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/RootPlugin.kt
+++ b/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/RootPlugin.kt
@@ -4,6 +4,7 @@ import net.twisterrob.gradle.common.BaseExposedPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class RootPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/RootPlugin.kt
+++ b/plugin/base/src/main/kotlin/net/twisterrob/gradle/root/RootPlugin.kt
@@ -4,7 +4,7 @@ import net.twisterrob.gradle.common.BaseExposedPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
-class RootPlugin : BaseExposedPlugin() {
+abstract class RootPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
+++ b/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
@@ -27,7 +27,7 @@ import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
-open class AndroidBuildPluginExtension {
+abstract class AndroidBuildPluginExtension {
 
 	var isDecorateBuildConfig: Boolean = true
 

--- a/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
+++ b/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
@@ -37,7 +37,7 @@ abstract class AndroidBuildPluginExtension {
 	}
 }
 
-class AndroidBuildPlugin : net.twisterrob.gradle.common.BasePlugin() {
+abstract class AndroidBuildPlugin : net.twisterrob.gradle.common.BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
+++ b/plugin/building/src/main/kotlin/net/twisterrob/gradle/android/AndroidBuildPlugin.kt
@@ -27,6 +27,7 @@ import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidBuildPluginExtension {
 
 	var isDecorateBuildConfig: Boolean = true
@@ -37,6 +38,7 @@ abstract class AndroidBuildPluginExtension {
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidBuildPlugin : net.twisterrob.gradle.common.BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaLibPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaLibPlugin.kt
@@ -1,5 +1,6 @@
 package net.twisterrob.gradle.java
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class JavaLibPlugin : BaseJavaPlugin() {
 
 	override fun applyDefaultPlugin() {

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaLibPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaLibPlugin.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.gradle.java
 
-class JavaLibPlugin : BaseJavaPlugin() {
+abstract class JavaLibPlugin : BaseJavaPlugin() {
 
 	override fun applyDefaultPlugin() {
 		project.plugins.apply("java-library")

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaPlugin.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.gradle.java
 
-class JavaPlugin : BaseJavaPlugin() {
+abstract class JavaPlugin : BaseJavaPlugin() {
 
 	override fun applyDefaultPlugin() {
 		project.plugins.apply("java")

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/java/JavaPlugin.kt
@@ -1,5 +1,6 @@
 package net.twisterrob.gradle.java
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class JavaPlugin : BaseJavaPlugin() {
 
 	override fun applyDefaultPlugin() {

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/kotlin/KotlinPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/kotlin/KotlinPlugin.kt
@@ -15,7 +15,7 @@ private typealias DependencyAdder = DependencyHandler.(Any) -> Dependency?
 
 const val VERSION_KOTLIN: String = "1.4.32"
 
-class KotlinPlugin : BasePlugin() {
+abstract class KotlinPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/languages/src/main/kotlin/net/twisterrob/gradle/kotlin/KotlinPlugin.kt
+++ b/plugin/languages/src/main/kotlin/net/twisterrob/gradle/kotlin/KotlinPlugin.kt
@@ -15,6 +15,7 @@ private typealias DependencyAdder = DependencyHandler.(Any) -> Dependency?
 
 const val VERSION_KOTLIN: String = "1.4.32"
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class KotlinPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -19,7 +19,7 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
-class AndroidMinificationPlugin : BasePlugin() {
+abstract class AndroidMinificationPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidMinificationPlugin.kt
@@ -19,6 +19,7 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidMinificationPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleaseExtension.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleaseExtension.kt
@@ -5,9 +5,9 @@ import net.twisterrob.gradle.kotlin.dsl.extensions
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.kotlin.dsl.getByName
 
-interface AndroidReleaseExtension {
+abstract class AndroidReleaseExtension {
 
-	val directory: DirectoryProperty
+	abstract val directory: DirectoryProperty
 
 	companion object {
 

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleaseExtension.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleaseExtension.kt
@@ -5,6 +5,7 @@ import net.twisterrob.gradle.kotlin.dsl.extensions
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.kotlin.dsl.getByName
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidReleaseExtension {
 
 	abstract val directory: DirectoryProperty

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
@@ -25,7 +25,7 @@ import java.io.File
 import java.io.IOException
 import java.util.zip.ZipFile
 
-class AndroidReleasePlugin : BasePlugin() {
+abstract class AndroidReleasePlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
+++ b/plugin/release/src/main/kotlin/net/twisterrob/gradle/android/AndroidReleasePlugin.kt
@@ -25,6 +25,7 @@ import java.io.File
 import java.io.IOException
 import java.util.zip.ZipFile
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidReleasePlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/settings/src/main/kotlin-shared/net/twisterrob/gradle/nagging/NaggingPlugin.kt
+++ b/plugin/settings/src/main/kotlin-shared/net/twisterrob/gradle/nagging/NaggingPlugin.kt
@@ -13,7 +13,7 @@ import org.gradle.api.initialization.Settings
  * }
  * ```
  */
-class NaggingPlugin : Plugin<Settings> {
+abstract class NaggingPlugin : Plugin<Settings> {
 	override fun apply(settings: Settings) {
 		settings.gradle.allowUnlimitedStacksForNagging()
 		settings.gradle.reviewIfNaggingCausesFailure()

--- a/plugin/settings/src/main/kotlin-shared/net/twisterrob/gradle/nagging/NaggingPlugin.kt
+++ b/plugin/settings/src/main/kotlin-shared/net/twisterrob/gradle/nagging/NaggingPlugin.kt
@@ -13,6 +13,7 @@ import org.gradle.api.initialization.Settings
  * }
  * ```
  */
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class NaggingPlugin : Plugin<Settings> {
 	override fun apply(settings: Settings) {
 		settings.gradle.allowUnlimitedStacksForNagging()

--- a/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPlugin.kt
+++ b/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.initialization.Settings
  * }
  * ```
  */
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class SettingsPlugin : Plugin<Settings> {
 	override fun apply(settings: Settings) {
 		// Nothing to do, yet.

--- a/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPlugin.kt
+++ b/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPlugin.kt
@@ -11,7 +11,7 @@ import org.gradle.api.initialization.Settings
  * }
  * ```
  */
-class SettingsPlugin : Plugin<Settings> {
+abstract class SettingsPlugin : Plugin<Settings> {
 	override fun apply(settings: Settings) {
 		// Nothing to do, yet.
 	}

--- a/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPluginDeprecated.kt
+++ b/plugin/settings/src/main/kotlin/net/twisterrob/gradle/settings/SettingsPluginDeprecated.kt
@@ -2,7 +2,8 @@ package net.twisterrob.gradle.settings
 
 import net.twisterrob.gradle.internal.deprecation.DeprecatedSettingsPlugin
 
-internal class SettingsPluginDeprecated : DeprecatedSettingsPlugin(
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
+internal abstract class SettingsPluginDeprecated : DeprecatedSettingsPlugin(
 	oldName = "net.twisterrob.settings",
 	newName = "net.twisterrob.gradle.plugin.settings",
 )

--- a/plugin/signing/src/main/kotlin/net/twisterrob/gradle/android/AndroidSigningPlugin.kt
+++ b/plugin/signing/src/main/kotlin/net/twisterrob/gradle/android/AndroidSigningPlugin.kt
@@ -6,7 +6,7 @@ import net.twisterrob.gradle.common.BasePlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.get
 
-class AndroidSigningPlugin : BasePlugin() {
+abstract class AndroidSigningPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/signing/src/main/kotlin/net/twisterrob/gradle/android/AndroidSigningPlugin.kt
+++ b/plugin/signing/src/main/kotlin/net/twisterrob/gradle/android/AndroidSigningPlugin.kt
@@ -6,6 +6,7 @@ import net.twisterrob.gradle.common.BasePlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.get
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidSigningPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidAppPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidAppPlugin.kt
@@ -6,6 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidAppPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidAppPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidAppPlugin.kt
@@ -6,7 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
-class AndroidAppPlugin : BaseExposedPlugin() {
+abstract class AndroidAppPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidLibraryPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidLibraryPlugin.kt
@@ -6,7 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
-class AndroidLibraryPlugin : BaseExposedPlugin() {
+abstract class AndroidLibraryPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidLibraryPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidLibraryPlugin.kt
@@ -6,6 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidLibraryPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidTestPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidTestPlugin.kt
@@ -6,6 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidTestPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidTestPlugin.kt
+++ b/plugin/src/main/kotlin/net/twisterrob/gradle/android/AndroidTestPlugin.kt
@@ -6,7 +6,7 @@ import net.twisterrob.gradle.vcs.VCSPlugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
-class AndroidTestPlugin : BaseExposedPlugin() {
+abstract class AndroidTestPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
@@ -46,7 +46,10 @@ import java.util.Properties
  * Note: in Groovy DSL this is automatic.
  * @see version
  */
-@Suppress("MemberVisibilityCanBePrivate")
+@Suppress(
+	"MemberVisibilityCanBePrivate",
+	"UnnecessaryAbstractClass", // Gradle convention.
+)
 abstract class AndroidVersionExtension {
 
 	private var isAutoVersionSet: Boolean = false
@@ -163,6 +166,7 @@ abstract class AndroidVersionExtension {
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class AndroidVersionPlugin : BasePlugin() {
 
 	private val android: AppExtension by lazy {

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
@@ -163,7 +163,7 @@ abstract class AndroidVersionExtension {
 	}
 }
 
-class AndroidVersionPlugin : BasePlugin() {
+abstract class AndroidVersionPlugin : BasePlugin() {
 
 	private val android: AppExtension by lazy {
 		if (!project.plugins.hasPlugin("com.android.application")) {

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/android/AndroidVersionPlugin.kt
@@ -47,7 +47,7 @@ import java.util.Properties
  * @see version
  */
 @Suppress("MemberVisibilityCanBePrivate")
-open class AndroidVersionExtension {
+abstract class AndroidVersionExtension {
 
 	private var isAutoVersionSet: Boolean = false
 

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
@@ -17,7 +17,7 @@ import org.gradle.kotlin.dsl.create
 import java.io.File
 import java.io.FileNotFoundException
 
-class GITPlugin : BasePlugin() {
+abstract class GITPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)
@@ -25,7 +25,7 @@ class GITPlugin : BasePlugin() {
 	}
 }
 
-open class GITPluginExtension(
+abstract class GITPluginExtension(
 	private val rootDir: File
 ) : VCSExtension {
 

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/GITPlugin.kt
@@ -17,6 +17,7 @@ import org.gradle.kotlin.dsl.create
 import java.io.File
 import java.io.FileNotFoundException
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GITPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
@@ -25,6 +26,7 @@ abstract class GITPlugin : BasePlugin() {
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GITPluginExtension(
 	private val rootDir: File
 ) : VCSExtension {

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/SVNPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/SVNPlugin.kt
@@ -18,6 +18,7 @@ import java.io.File
 import java.io.PrintStream
 import java.security.Permission
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class SVNPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
@@ -26,6 +27,7 @@ abstract class SVNPlugin : BasePlugin() {
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class SVNPluginExtension(
 	private val rootDir: File
 ) : VCSExtension {

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/SVNPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/SVNPlugin.kt
@@ -18,7 +18,7 @@ import java.io.File
 import java.io.PrintStream
 import java.security.Permission
 
-class SVNPlugin : BasePlugin() {
+abstract class SVNPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)
@@ -26,7 +26,7 @@ class SVNPlugin : BasePlugin() {
 	}
 }
 
-open class SVNPluginExtension(
+abstract class SVNPluginExtension(
 	private val rootDir: File
 ) : VCSExtension {
 

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/VCSPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/VCSPlugin.kt
@@ -8,7 +8,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByName
 
-open class VCSPluginExtension : VCSExtension {
+abstract class VCSPluginExtension : VCSExtension {
 
 	var current: VCSExtension = DummyVcsExtension
 		internal set
@@ -43,7 +43,7 @@ open class VCSPluginExtension : VCSExtension {
 	}
 }
 
-class VCSPlugin : BaseExposedPlugin() {
+abstract class VCSPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/VCSPlugin.kt
+++ b/plugin/versioning/src/main/kotlin/net/twisterrob/gradle/vcs/VCSPlugin.kt
@@ -8,6 +8,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByName
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class VCSPluginExtension : VCSExtension {
 
 	var current: VCSExtension = DummyVcsExtension
@@ -43,6 +44,7 @@ abstract class VCSPluginExtension : VCSExtension {
 	}
 }
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class VCSPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/LintPlugin.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/LintPlugin.kt
@@ -5,6 +5,7 @@ import net.twisterrob.gradle.common.registerTask
 import net.twisterrob.gradle.quality.tasks.GlobalLintGlobalFinalizerTask
 import org.gradle.api.Project
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 internal abstract class LintPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/LintPlugin.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/LintPlugin.kt
@@ -5,7 +5,7 @@ import net.twisterrob.gradle.common.registerTask
 import net.twisterrob.gradle.quality.tasks.GlobalLintGlobalFinalizerTask
 import org.gradle.api.Project
 
-internal open class LintPlugin : BasePlugin() {
+internal abstract class LintPlugin : BasePlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityExtension.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityExtension.kt
@@ -8,7 +8,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.kotlin.dsl.getByType
 
-open class QualityExtension(
+abstract class QualityExtension(
 	val project: Project
 ) {
 

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityExtension.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityExtension.kt
@@ -8,6 +8,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.kotlin.dsl.getByType
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class QualityExtension(
 	val project: Project
 ) {

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityPlugin.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityPlugin.kt
@@ -13,6 +13,7 @@ import net.twisterrob.gradle.quality.tasks.ValidateViolationsTask
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class QualityPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityPlugin.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/QualityPlugin.kt
@@ -13,7 +13,7 @@ import net.twisterrob.gradle.quality.tasks.ValidateViolationsTask
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
-class QualityPlugin : BaseExposedPlugin() {
+abstract class QualityPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTask.kt
@@ -19,6 +19,7 @@ import org.gradle.work.DisableCachingByDefault
 import se.bjurr.violations.lib.model.SEVERITY
 
 @DisableCachingByDefault(because = "Base class is not cacheable yet. (Gradle 8.0)")
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class GlobalTestFinalizerTask : TestReport() {
 
 	/**

--- a/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTask.kt
+++ b/quality/src/main/kotlin/net/twisterrob/gradle/quality/tasks/GlobalTestFinalizerTask.kt
@@ -19,7 +19,7 @@ import org.gradle.work.DisableCachingByDefault
 import se.bjurr.violations.lib.model.SEVERITY
 
 @DisableCachingByDefault(because = "Base class is not cacheable yet. (Gradle 8.0)")
-open class GlobalTestFinalizerTask : TestReport() {
+abstract class GlobalTestFinalizerTask : TestReport() {
 
 	/**
 	 * Need to save the value to a field, so that we can query the provider in @TaskAction.

--- a/test/internal/runtime/src/main/kotlin/net/twisterrob/gradle/nagging/NaggingPluginForTest.kt
+++ b/test/internal/runtime/src/main/kotlin/net/twisterrob/gradle/nagging/NaggingPluginForTest.kt
@@ -7,8 +7,11 @@ import org.gradle.api.plugins.ExtensionAware
 /**
  * Used from `init.gradle.kts` in test resources.
  */
-@Suppress("unused") // Used from nagging.init.gradle.kts
-class NaggingPluginForTest : Plugin<Gradle> {
+@Suppress(
+	"unused", // Used from nagging.init.gradle.kts
+	"UnnecessaryAbstractClass",  // Gradle convention.
+)
+abstract class NaggingPluginForTest : Plugin<Gradle> {
 	override fun apply(gradle: Gradle) {
 		gradle.rootProject(::exposeDoNotNagAboutExtras)
 		gradle.beforeSettings(::exposeDoNotNagAboutExtras)

--- a/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
+++ b/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestInstancePostProcessor
 
-abstract class GradleRunnerRuleExtension : TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
+class GradleRunnerRuleExtension : TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
 
 	private val rule = object : GradleRunnerRule() {
 

--- a/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
+++ b/test/internal/src/main/kotlin/net/twisterrob/gradle/test/GradleRunnerRuleExtension.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestInstancePostProcessor
 
-open class GradleRunnerRuleExtension : TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
+abstract class GradleRunnerRuleExtension : TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
 
 	private val rule = object : GradleRunnerRule() {
 

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
@@ -5,8 +5,8 @@ import org.gradle.api.Project
 import java.net.JarURLConnection
 import java.util.jar.Attributes
 
-@Suppress("UnnecessaryAbstractClass") // Gradle convention.
-abstract class TestPlugin : BaseExposedPlugin() {
+//@Suppress("UnnecessaryAbstractClass") // Gradle convention.
+class TestPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import java.net.JarURLConnection
 import java.util.jar.Attributes
 
+@Suppress("UnnecessaryAbstractClass") // Gradle convention.
 abstract class TestPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {

--- a/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
+++ b/test/src/main/kotlin/net/twisterrob/gradle/test/TestPlugin.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 import java.net.JarURLConnection
 import java.util.jar.Attributes
 
-class TestPlugin : BaseExposedPlugin() {
+abstract class TestPlugin : BaseExposedPlugin() {
 
 	override fun apply(target: Project) {
 		super.apply(target)


### PR DESCRIPTION
Triggered by 
```
e: file:///home/runner/work/net.twisterrob.gradle/net.twisterrob.gradle/checkers/pmd/src/main/kotlin/net/twisterrob/gradle/pmd/PmdTask.kt:11:6 Class 'PmdTask' is not abstract and does not implement abstract base class member protected/*protected and package*/ abstract fun getIgnoreFailuresProperty(): Property<Boolean!>! defined in org.gradle.api.plugins.quality.Pmd
> Task :pmd:compileKotlin FAILED
```
* [CI](https://github.com/TWiStErRob/net.twisterrob.gradle/actions/runs/6262175743/job/17003769964?pr=596#step:6:113) on https://github.com/TWiStErRob/net.twisterrob.cinema/pull/552