### PR TITLE
Fix javafxplugin dependency lookup in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"local>TWiStErRob/renovate-config"
+		"github>TWiStErRob/renovate-config"
 	],
 	"ignorePaths": [
 		"**/src/test/resources/**"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build outputs
 .gradle/
+.kotlin/
 /build/
 /*/build/
 /*/*/build/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,10 @@ rootProject.name = "net-twisterrob-gradle"
 pluginManagement {
 	includeBuild("gradle/plugins")
 	includeBuild("graph")
+	repositories {
+		// This is the default, but it helps Renovate to resolve some plugins.
+		gradlePluginPortal()
+	}
 }
 
 plugins {


### PR DESCRIPTION
Fixes:

---

> [!WARNING]
> Renovate failed to look up the following dependencies: `Failed to look up maven package org.openjfx.javafxplugin:org.openjfx.javafxplugin.gradle.plugin`.
> 
> Files affected: `graph/build.gradle.kts`

---