### PR TITLE
Remove exposed direct classpath, use group plugin instead

### DIFF
--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/createJavaVariant.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/publishing/createJavaVariant.kt
@@ -52,7 +52,7 @@ private fun HasAttributes.copyAttributesFrom(
 	}
 }
 
-private val ignore = Attribute.of("ignore", String::class.java)
+private val ignore = Attribute.of("net.twisterrob.ignore", String::class.java)
 
 private fun Project.skipConfiguration(configuration: NamedDomainObjectProvider<Configuration>) {
 	configuration.configure {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/net.twisterrob.gradle.build.testing.plugin-under-test-metadata-extras.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/gradle/build/testing/net.twisterrob.gradle.build.testing.plugin-under-test-metadata-extras.gradle.kts
@@ -66,6 +66,6 @@ configurations {
 		isCanBeResolved = true
 	}
 	tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
-		this.pluginClasspath.from(testInjectedPluginClasspath)
+		pluginClasspath.from(testInjectedPluginClasspath)
 	}
 }

--- a/plugin/building/build.gradle.kts
+++ b/plugin/building/build.gradle.kts
@@ -23,14 +23,14 @@ dependencies {
 	compileOnly(libs.android.tools.common)
 	compileOnly(libs.annotations.jetbrains)
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(testFixtures(projects.plugin.base))
 	testImplementation(testFixtures(projects.plugin.versioning))
 	// AndroidInstallRunnerTaskTest calls production code directly, so need com.android.xml.AndroidXPathFactory.
 	testRuntimeOnly(libs.android.tools.common)
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/languages/build.gradle.kts
+++ b/plugin/languages/build.gradle.kts
@@ -48,11 +48,11 @@ dependencies {
 	api(projects.plugin.base)
 	compileOnly(libs.android.gradle)
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(testFixtures(projects.plugin.base))
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/release/build.gradle.kts
+++ b/plugin/release/build.gradle.kts
@@ -25,11 +25,11 @@ dependencies {
 	implementation(projects.compat.agpBase)
 	implementation(projects.compat.agp)
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(testFixtures(projects.plugin.base))
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/reporting/build.gradle.kts
+++ b/plugin/reporting/build.gradle.kts
@@ -21,11 +21,11 @@ dependencies {
 	// Need com.android.utils.FileUtils for TestReportGenerator.generate().
 	compileOnly(libs.android.tools.common)
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(testFixtures(projects.plugin.base))
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/signing/build.gradle.kts
+++ b/plugin/signing/build.gradle.kts
@@ -18,12 +18,12 @@ dependencies {
 	api(projects.plugin.base)
 	compileOnly(libs.android.gradle)
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(projects.compat.agpBase)
 	testImplementation(testFixtures(projects.plugin.base))
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/versioning/build.gradle.kts
+++ b/plugin/versioning/build.gradle.kts
@@ -59,7 +59,17 @@ dependencies {
 	testImplementation(testFixtures(projects.plugin.base))
 
 	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	testInjectedPluginClasspath(projects.plugin)
+	testInjectedPluginClasspath(projects.plugin) {
+		// Hacky workaround for class-file-version problems at runtime.
+		// There's probably a variant-attribute based solution, but couldn't figure it out in time.
+		libs.jgit17.get().module.run { exclude(group, name) }
+	}
+	testInjectedPluginClasspath(
+		providers
+			.gradleProperty("net.twisterrob.test.gradle.javaVersion")
+			.flatMap { libs.create("jgit${it}") } // libs.jgit11 / libs.jgit17
+	)
+
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}

--- a/plugin/versioning/build.gradle.kts
+++ b/plugin/versioning/build.gradle.kts
@@ -55,11 +55,11 @@ dependencies {
 		versionConstraint.rejectedVersions.add("(,7.0)")
 	}
 
-	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
-	runtimeOnly(projects.plugin)
-
 	testImplementation(projects.test.internal)
 	testImplementation(testFixtures(projects.plugin.base))
+
+	// This plugin is part of the net.twisterrob.gradle.plugin.android-app plugin, not designed to work on its own.
+	testInjectedPluginClasspath(projects.plugin)
 	testInjectedPluginClasspath(libs.android.gradle) {
 		version { require(property("net.twisterrob.test.android.pluginVersion").toString()) }
 	}


### PR DESCRIPTION
Directly referencing a convention plugin is not supported, use the `twister-convention-plugins` artifact instead.


Triggered by: https://issuetracker.google.com/issues/391903237
```
net.twisterrob.gradle>gradlew lint

FAILURE: Build failed with an exception.

* What went wrong:
Circular dependency between the following tasks:
:plugin:generateJvmMainLintModel
+--- :plugin:generateJvmMainLintModel (*)
+--- :plugin:building:generateJvmMainLintModel
|    +--- :plugin:generateJvmMainLintModel (*)
|    +--- :plugin:building:generateJvmMainLintModel (*)
|    +--- :plugin:languages:generateJvmMainLintModel
|    |    +--- :plugin:generateJvmMainLintModel (*)
|    |    +--- :plugin:building:generateJvmMainLintModel (*)
|    |    +--- :plugin:languages:generateJvmMainLintModel (*)
|    |    +--- :plugin:release:generateJvmMainLintModel
|    |    |    +--- :plugin:generateJvmMainLintModel (*)
|    |    |    +--- :plugin:building:generateJvmMainLintModel (*)
|    |    |    +--- :plugin:languages:generateJvmMainLintModel (*)
|    |    |    +--- :plugin:release:generateJvmMainLintModel (*)
|    |    |    +--- :plugin:reporting:generateJvmMainLintModel
|    |    |    |    +--- :plugin:generateJvmMainLintModel (*)
|    |    |    |    +--- :plugin:building:generateJvmMainLintModel (*)
|    |    |    |    +--- :plugin:languages:generateJvmMainLintModel (*)
|    |    |    |    +--- :plugin:release:generateJvmMainLintModel (*)
|    |    |    |    +--- :plugin:reporting:generateJvmMainLintModel (*)
|    |    |    |    \--- :plugin:signing:generateJvmMainLintModel
|    |    |    |         +--- :plugin:generateJvmMainLintModel (*)
|    |    |    |         +--- :plugin:building:generateJvmMainLintModel (*)
|    |    |    |         +--- :plugin:languages:generateJvmMainLintModel (*)
|    |    |    |         +--- :plugin:release:generateJvmMainLintModel (*)
|    |    |    |         +--- :plugin:reporting:generateJvmMainLintModel (*)
|    |    |    |         \--- :plugin:signing:generateJvmMainLintModel (*)
|    |    |    +--- :plugin:signing:generateJvmMainLintModel (*)
|    |    |    \--- :plugin:versioning:generateJvmMainLintModel
|    |    |         +--- :plugin:generateJvmMainLintModel (*)
|    |    |         +--- :plugin:building:generateJvmMainLintModel (*)
|    |    |         +--- :plugin:languages:generateJvmMainLintModel (*)
|    |    |         +--- :plugin:release:generateJvmMainLintModel (*)
|    |    |         +--- :plugin:reporting:generateJvmMainLintModel (*)
|    |    |         \--- :plugin:signing:generateJvmMainLintModel (*)
|    |    +--- :plugin:reporting:generateJvmMainLintModel (*)
|    |    \--- :plugin:signing:generateJvmMainLintModel (*)
|    +--- :plugin:release:generateJvmMainLintModel (*)
|    +--- :plugin:reporting:generateJvmMainLintModel (*)
|    +--- :plugin:signing:generateJvmMainLintModel (*)
|    \--- :plugin:versioning:generateJvmMainLintModel (*)
+--- :plugin:languages:generateJvmMainLintModel (*)
+--- :plugin:release:generateJvmMainLintModel (*)
+--- :plugin:reporting:generateJvmMainLintModel (*)
+--- :plugin:signing:generateJvmMainLintModel (*)
\--- :plugin:versioning:generateJvmMainLintModel (*)

(*) - details omitted (listed previously)
```

also reported https://github.com/gradle/gradle/issues/32172